### PR TITLE
feat: add openapi generation workflows

### DIFF
--- a/.github/workflows/openapi-generate-go-client.yaml
+++ b/.github/workflows/openapi-generate-go-client.yaml
@@ -1,0 +1,71 @@
+name: Openapi Generate GO Client
+on:
+  workflow_call:
+    inputs:
+      specLocation:
+        description: The filepath to the openapi spec.
+        required: false
+        type: string
+        default: openapi.yaml
+      payload:
+        description: The base64 encoded openapi spec. Written to the spec filepath if present.
+        required: false
+        type: string
+      version:
+        description: The openapi generator version used.
+        required: false
+        type: string
+        default: v6.2.0
+      organization:
+        description: The organization to use when generating the client.
+        required: false
+        type: string
+        default: $${{ github.repository_owner }}
+      package:
+        description: The name of the package to generate the code in.
+        required: true
+        type: string
+      options:
+        description: Additional options passed to the generator command.
+        required: false
+        type: string
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Remove Generated Files
+        continue-on-error: true
+        run: xargs -I{} rm -rf "{}" < .openapi-generator/FILES
+      - name: Write Spec
+        run: |
+          mkdir -p api
+          if [[ ! -z "${{ inputs.payload }}" ]]
+          then
+            echo "${{ inputs.payload }}" | base64 --decode > ${{ inputs.specLocation }}
+          fi
+          cat ${{ inputs.specLocation }}
+      - name: Read Spec
+        id: spec
+        uses: CumulusDS/get-yaml-paths-action@v0.1.0
+        with:
+          file: ${{ inputs.specLocation }}
+          title: info.title
+          version: info.version
+      - name: Generate GO Client
+        uses: openapi-generators/openapitools-generator-action@v1
+        with:
+          generator: go
+          generator-tag: ${{ inputs.version }}
+          openapi-file: ${{ inputs.specLocation }}
+          command-args: --git-user-id $${{ inputs.organization }} --git-repo-id ${{ github.event.repository.name }} --additional-properties=isGoSubmodule=true --package-name ${{ inputs.package }} ${{ inputs.options }} -o .
+      - name: Remove Spec
+        run: rm -f ${{ inputs.specLocation }}
+      - name: Commit
+        uses: EndBug/add-and-commit@v7
+        with:
+          default_author: github_actions
+          message: "${{ steps.spec.outputs.title }} ${{ steps.spec.outputs.version }}"
+          tag: ${{ steps.spec.outputs.version }}

--- a/.github/workflows/openapi-generate-php-client.yaml
+++ b/.github/workflows/openapi-generate-php-client.yaml
@@ -1,0 +1,71 @@
+name: Openapi Generate PHP Client
+on:
+  workflow_call:
+    inputs:
+      specLocation:
+        description: The filepath to the openapi spec.
+        required: false
+        type: string
+        default: openapi.yaml
+      payload:
+        description: The base64 encoded openapi spec. Written to the spec filepath if present.
+        required: false
+        type: string
+      version:
+        description: The openapi generator version used.
+        required: false
+        type: string
+        default: v5.2.0
+      organization:
+        description: The organization to use when generating the client.
+        required: false
+        type: string
+        default: $${{ github.repository_owner }}
+      package:
+        description: The name of the package to generate the code in.
+        required: true
+        type: string
+      options:
+        description: Additional options passed to the generator command.
+        required: false
+        type: string
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Remove Generated Files
+        continue-on-error: true
+        run: xargs -I{} rm -rf "{}" < .openapi-generator/FILES
+      - name: Write Spec
+        run: |
+          mkdir -p api
+          if [[ ! -z "${{ inputs.payload }}" ]]
+          then
+            echo "${{ inputs.payload }}" | base64 --decode > ${{ inputs.specLocation }}
+          fi
+          cat ${{ inputs.specLocation }}
+      - name: Read Spec
+        id: spec
+        uses: CumulusDS/get-yaml-paths-action@v0.1.0
+        with:
+          file: ${{ inputs.specLocation }}
+          title: info.title
+          version: info.version
+      - name: Generate PHP Client
+        uses: openapi-generators/openapitools-generator-action@v1
+        with:
+          generator: php
+          generator-tag: ${{ inputs.version }}
+          openapi-file: ${{ inputs.specLocation }}
+          command-args: --git-user-id $${{ inputs.organization }} --git-repo-id ${{ github.event.repository.name }} --additional-properties=invokerPackage=${{ inputs.package }} ${{ inputs.options }} -o .
+      - name: Remove Spec
+        run: rm -f ${{ inputs.specLocation }}
+      - name: Commit
+        uses: EndBug/add-and-commit@v7
+        with:
+          default_author: github_actions
+          message: "${{ steps.spec.outputs.title }} ${{ steps.spec.outputs.version }}"
+          tag: ${{ steps.spec.outputs.version }}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
add openapi generation workflows for Golang and PHP.
intended to be called in generated client repos by triggered dispatch actions.
Will allow for CI changes to be made in one place for our generated workflows

## Testing information
<!--- Please describe in detail how you tested your changes. -->
<!--- This section should be through enough that reviewers can replicate the testing. -->

## Issue link
<!-- Add a link to the issue -->

## Pre-review checklist

If some steps are not applicable or in your judgment not necessary, remove and explain why rather than leave checkmarks blank.

- [ ] I've tested the code as an end user would and included appropriate testing steps 
- [ ] For all new functionality, I have added thorough, applicable tests that validate my changes
- [x] For improvements to existing functionality, I've followed the [campsite rule](https://github.com/encodium/.github-private/blob/main/profile/pages/dev-standards.md#git), leaving it a little better than I found it. 
- [ ] The added feature contains necessary observability
- [x] I have made corresponding changes to the documentation

## Review checklist
- [ ] Review with peer on team.
- [ ] Review with team 'merger' or on-duty merger. Details [here](https://github.com/encodium/.github-private/blob/main/profile/pages/dev-standards.md#git). 

## Peer review checklist

- [ ] Make sure the pre-review checklist has been completed.
- [ ] I've run the code as an end user would.

## Merger review checklist

- [ ] Make sure the pre-review checklist has been completed.
- [ ] I've run the code as an end user would.

## Attachments
<!-- This section is optional, but should be used to share items such as UI screenshots or test files, when applicable -->