### PR TITLE
ci: stop generating client as submodule

### DIFF
--- a/.github/workflows/openapi-generate-go-client.yaml
+++ b/.github/workflows/openapi-generate-go-client.yaml
@@ -95,7 +95,7 @@ jobs:
           openapi-file: ${{ inputs.specLocation }}
           command-args: |
             --git-user-id ${{ inputs.organization }} --git-repo-id ${{ github.event.repository.name }} \
-            --additional-properties=isGoSubmodule=true --package-name ${{ inputs.package }} \
+            --package-name ${{ inputs.package }} \
             ${{ steps.set-config.outputs.OPENAPI_CONFIG }} \
             ${{ steps.set-template.outputs.OPENAPI_TEMPLATE }} \
             -o .


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Stop generating the go package as a submodule, the client generation is now done at the root level

## Testing information
<!--- Please describe in detail how you tested your changes. -->
<!--- This section should be through enough that reviewers can replicate the testing. -->

## Issue link
<!-- Add a link to the issue -->

## Pre-review checklist

If some steps are not applicable or in your judgment not necessary, remove and explain why rather than leave checkmarks blank.

- [ ] I've tested the code as an end user would and included appropriate testing steps 
- [ ] For all new functionality, I have added thorough, applicable tests that validate my changes
- [ ] For improvements to existing functionality, I've followed the [campsite rule](https://github.com/encodium/.github-private/blob/main/profile/pages/dev-standards.md#git), leaving it a little better than I found it. 
- [ ] The added feature contains necessary observability
- [ ] I have made corresponding changes to the documentation

## Review checklist
- [ ] Review with peer on team.
- [ ] Review with team 'merger' or on-duty merger. Details [here](https://github.com/encodium/.github-private/blob/main/profile/pages/dev-standards.md#git). 

## Peer review checklist

- [ ] Make sure the pre-review checklist has been completed.
- [ ] I've run the code as an end user would.

## Merger review checklist

- [ ] Make sure the pre-review checklist has been completed.
- [ ] I've run the code as an end user would.

## Attachments
<!-- This section is optional, but should be used to share items such as UI screenshots or test files, when applicable -->