### PR TITLE
feat: openapi ci lint action

### DIFF
--- a/.github/workflows/openapi-lint.yml
+++ b/.github/workflows/openapi-lint.yml
@@ -1,0 +1,20 @@
+name: Lint an OpenAPI spec with inso
+on:
+  workflow_call:
+    inputs:
+      specLocation:
+        description: The filepath to the openapi spec.
+        required: true
+        type: string
+
+jobs:
+  openapi-linter:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v2
+      - uses: kong/setup-inso@v1
+        with:
+            inso-version: 3.5.0
+      - name: Lint OpenAPI spec
+        run: inso lint spec "${{ inputs.specLocation }}"


### PR DESCRIPTION
## Description
This PR makes a shared Encodium action to make it easier for all repos to lint their OpenAPI spec in CI
See also https://github.com/encodium/internal_api/pull/2961 and https://github.com/encodium/products-api/pull/437
## Testing information
<!--- Please describe in detail how you tested your changes. -->
<!--- This section should be through enough that reviewers can replicate the testing. -->

## Issue link
<!-- Add a link to the issue -->

## Pre-review checklist

If some steps are not applicable or in your judgment not necessary, remove and explain why rather than leave checkmarks blank.

- [ ] I've tested the code as an end user would and included appropriate testing steps 
- [ ] For all new functionality, I have added thorough, applicable tests that validate my changes
- [ ] For improvements to existing functionality, I've followed the [campsite rule](https://github.com/encodium/.github-private/blob/main/profile/pages/dev-standards.md#git), leaving it a little better than I found it. 
- [ ] The added feature contains necessary observability
- [ ] I have made corresponding changes to the documentation

## Review checklist
- [ ] Review with peer on team.
- [ ] Review with team 'merger' or on-duty merger. Details [here](https://github.com/encodium/.github-private/blob/main/profile/pages/dev-standards.md#git). 

## Peer review checklist

- [ ] Make sure the pre-review checklist has been completed.
- [ ] I've run the code as an end user would.

## Merger review checklist

- [ ] Make sure the pre-review checklist has been completed.
- [ ] I've run the code as an end user would.

## Attachments
<!-- This section is optional, but should be used to share items such as UI screenshots or test files, when applicable -->