### PR TITLE
ci: lint on all files, not only changed lines

### DIFF
--- a/.github/workflows/action-lint.yml
+++ b/.github/workflows/action-lint.yml
@@ -10,3 +10,4 @@ jobs:
       - uses: reviewdog/action-actionlint@v1
         with:
           fail_on_error: true
+          filter_mode: "nofilter"


### PR DESCRIPTION
## Description
This action originally only linted when an affected line was in your diff, this should change it to always lint on all files, alerting us to action deprecation without us having to modify the file at all

https://github.com/reviewdog/reviewdog#nofilter


## Testing information
<!--- Please describe in detail how you tested your changes. -->
<!--- This section should be through enough that reviewers can replicate the testing. -->

## Issue link
<!-- Add a link to the issue -->

## Pre-review checklist

If some steps are not applicable or in your judgment not necessary, remove and explain why rather than leave checkmarks blank.

- [ ] I've tested the code as an end user would and included appropriate testing steps 
- [ ] For all new functionality, I have added thorough, applicable tests that validate my changes
- [ ] For improvements to existing functionality, I've followed the [campsite rule](https://github.com/encodium/.github-private/blob/main/profile/pages/dev-standards.md#git), leaving it a little better than I found it. 
- [ ] The added feature contains necessary observability
- [ ] I have made corresponding changes to the documentation

## Review checklist
- [ ] Review with peer on team.
- [ ] Review with team 'merger' or on-duty merger. Details [here](https://github.com/encodium/.github-private/blob/main/profile/pages/dev-standards.md#git). 

## Peer review checklist

- [ ] Make sure the pre-review checklist has been completed.
- [ ] I've run the code as an end user would.

## Merger review checklist

- [ ] Make sure the pre-review checklist has been completed.
- [ ] I've run the code as an end user would.

## Attachments
<!-- This section is optional, but should be used to share items such as UI screenshots or test files, when applicable -->