### PR TITLE
ci: create release with typescript client generation

### DIFF
--- a/.github/workflows/openapi-generate-typescript-client.yaml
+++ b/.github/workflows/openapi-generate-typescript-client.yaml
@@ -107,3 +107,8 @@ jobs:
           default_author: github_actions
           message: "${{ steps.spec.outputs.title }} ${{ steps.spec.outputs.version }}"
           tag: ${{ steps.spec.outputs.version }}
+      - name: Create a GitHub release
+        id: create_release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.spec.outputs.version }}


### PR DESCRIPTION
Create a github release from the updated generated client commit tag.
This will be used as a trigger to publish the npm package