### PR TITLE
ci: publish npm package

### DIFF
--- a/.github/workflows/openapi-generate-typescript-client.yaml
+++ b/.github/workflows/openapi-generate-typescript-client.yaml
@@ -107,8 +107,12 @@ jobs:
           default_author: github_actions
           message: "${{ steps.spec.outputs.title }} ${{ steps.spec.outputs.version }}"
           tag: ${{ steps.spec.outputs.version }}
-      - name: Create a GitHub release
-        id: create_release
-        uses: ncipollo/release-action@v1
+      - name: Node Setup
+        uses: actions/setup-node@v3
+      - run: npm install
+      - run: npm run build
+      - uses: JS-DevTools/npm-publish@v1
         with:
-          tag: ${{ steps.spec.outputs.version }}
+          access: restricted
+          registry: https://npm.pkg.github.com/
+          token: ${{ secrets.token }}


### PR DESCRIPTION
Github, for security reasons, will not allow a triggering a workflow _from_ a triggered workflow
https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
> When you use the repository's GITHUB_TOKEN to perform tasks, events triggered by the GITHUB_TOKEN, with the exception of workflow_dispatch and repository_dispatch, will not create a new workflow run. This prevents you from accidentally creating recursive workflow runs. For example, if a workflow run pushes code using the repository's GITHUB_TOKEN, a new workflow will not run even when the repository contains a workflow configured to run when push events occur.

instead we will publish npm package in generate job. This is effectively what the GO workflow does anyway and saves us from needing to copy another workflow around