### PR TITLE
chore: stop creating tags when building laravel apps

### DIFF
--- a/.github/workflows/php-laravel-build-push.yaml
+++ b/.github/workflows/php-laravel-build-push.yaml
@@ -98,11 +98,6 @@ jobs:
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.new_tag }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
-      - name: Bump version and push tag
-        id: tag_version
-        uses: mathieudutour/github-tag-action@v6.1
-        with:
-          github_token: ${{ secrets.gh_token }}
   build-and-push-webserver-image:
     runs-on: ubuntu-latest
     name: Build + Push Webserver (e.g. nginx) Image
@@ -130,8 +125,3 @@ jobs:
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:webserver-${{ inputs.new_tag }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:webserver-latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
-      - name: Bump version and push tag
-        id: tag_version
-        uses: mathieudutour/github-tag-action@v6.1
-        with:
-          github_token: ${{ secrets.gh_token }}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Previously when using the `laravel-build-push` workflow in repos 2 tags would be created. The responsibility for creating tags should be on the repo that uses this workflow instead, and only 1 tag should be created anyway.

Merging should be coordinated with these PRs:
- https://github.com/encodium/channels-api/pull/46
- https://github.com/encodium/example-laravel-api/pull/21