### PR TITLE
ci: update go version ~1.20.5

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.3
+          go-version: ~1.20.5
           check-latest: true
       - name: Go mod cache
         id: go-cache


### PR DESCRIPTION
govulncheck has an identified a security vulnerability in the runtime package v1.20.4 that is resolved in v1.20.5