### PR TITLE
ci: update docker layer caching action

### DIFF
--- a/.github/workflows/go-test-integration.yaml
+++ b/.github/workflows/go-test-integration.yaml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Go mod cache
         id: go-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cache/go-build
@@ -43,7 +43,7 @@ jobs:
       - name: Docker compose pull
         run: docker compose --file ./build/docker-compose.yml --file ./build/docker-compose.test.yml --project-directory . pull
       - name: Docker layer caching
-        uses: satackey/action-docker-layer-caching@v0.0.11
+        uses: jpribyl/action-docker-layer-caching@v0.1.1
         continue-on-error: true
       - name: Docker compose up
         run: docker compose --file ./build/docker-compose.yml --file ./build/docker-compose.test.yml --project-directory . up --build --abort-on-container-exit ${{ inputs.services }} --exit-code-from integration-test


### PR DESCRIPTION
The docker layer caching action appears to be causing issues with the intergration test job.
The output includes several warnings of deprecated features. 
docker compose steps after this action are unable to complete 
updating to a fork of the action that is maintained 
https://github.com/satackey/action-docker-layer-caching/issues/347

Hung job with warnings that would never complete: 
https://github.com/encodium/products-api/actions/runs/5627127731/job/15249164880

Tested and successful job with the forked action:
https://github.com/encodium/products-api/actions/runs/5627127731/job/15249164311
