### PR TITLE
chore: add sonarcloud section to pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,10 @@
 ## Issue link
 <!-- Add a link to the issue -->
 
+## Sonar Test Coverage
+<!-- If your PR does not pass the SonarCloud Code Analysis, describe how that it is justified to not pass -->
+- [ ] SonarCloud Code Analysis for this pull request is passing
+
 ## Pre-review checklist
 
 If some steps are not applicable or in your judgment not necessary, remove and explain why rather than leave checkmarks blank.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@
 <!-- Add a link to the issue -->
 
 ## Sonar Test Coverage
-<!-- If your PR does not pass the SonarCloud Code Analysis, describe how that it is justified to not pass -->
+<!-- If your PR does not pass the SonarCloud Code Analysis, describe why it cannot pass before merging. -->
 - [ ] SonarCloud Code Analysis for this pull request is passing
 
 ## Pre-review checklist


### PR DESCRIPTION
We have a decision log that removes SonarCloud Scan as a required gate
in pull requests (https://revolutionparts.slite.com/app/docs/kvtcXZjbaQQHZU);
however, we would like developers to describe why the pull request should be
merged if the SonarCloud scan fails because of coverage, smells, etc.

Jira Issue: [BOFH-469](https://revolutionparts.atlassian.net/browse/BOFH-469)



[BOFH-469]: https://revolutionparts.atlassian.net/browse/BOFH-469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ