### PR TITLE
ci: use latest stable go version

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.5
+          go-version: stable
           check-latest: true
       - name: Go mod cache
         id: go-cache


### PR DESCRIPTION
## Description
<!--
short description or bulleted list of what the pull request contains

**Related PRs:**
- https://github.com/encodium/webstore/pull/1234
- https://github.com/encodium/common/pull/4321
-->
Updating the `go-test` github action to use the latest stable go version.
https://github.com/actions/setup-go#using-stableoldstable-aliases

## Background
<!--
explain the _how_ and _why_ we need this
- [relevant context]
- [why you decided to change things]
- [reason you're doing it now]
-->
This will remove a required manual code every time there is a go release or patch.
We should always be using the latest stable version of GO

## Testing Information
<!--
Please describe in detail how you tested your changes. Steps to Reproduce, etc.
This section should be thorough enough that reviewers can replicate the testing.
-->

<!--
## Sonar Test Coverage
If your PR does not pass the SonarCloud Code Analysis, describe why it cannot pass before merging.
-->
<!--
For more information about creating PRs: https://revolutionparts.slite.com/app/docs/wLef9fVzlT0MDA/Creating-Pull-Requests
-->