### PR TITLE
feat: add "--atomic" option

### DIFF
--- a/.github/workflows/helm-deploy.yaml
+++ b/.github/workflows/helm-deploy.yaml
@@ -57,7 +57,7 @@ jobs:
           if [[ "${{ inputs.helm-wait }}" == "atomic" ]]; then
             WAIT_ARG="--atomic"
           fi
-          helm upgrade ${{ github.event.repository.name }} ./deployments --install $WAIT_ARG --set image.tag="${{ inputs.image_tag }}" -n ${{ inputs.namespace }} ${ARG_VALUES_FILE}
+          helm upgrade ${{ github.event.repository.name }} ./deployments --install ${WAIT_ARG} --set image.tag="${{ inputs.image_tag }}" -n ${{ inputs.namespace }} ${ARG_VALUES_FILE}
       - name: Update GitHub release
         if: inputs.environment == 'prod'
         uses: ncipollo/release-action@v1

--- a/.github/workflows/helm-deploy.yaml
+++ b/.github/workflows/helm-deploy.yaml
@@ -19,11 +19,11 @@ on:
         description: "Target environment for deployment (stg|prod)"
         required: true
         type: string
-      helm-wait:
-        description: "If set to 'atomic' will use --atomic enabling auto-rollback instead of --wait"
-        default: "wait"
+      atomic:
+        description: "If true, helm upgrade uses --atomic enabling auto-rollback upon failure"
+        default: false
         required: false
-        type: string
+        type: boolean
     secrets:
       k8s_server:
         required: true
@@ -54,7 +54,7 @@ jobs:
             ARG_VALUES_FILE="-f ${{ inputs.values-file }}"
           fi
           WAIT_ARG="--wait"
-          if [[ "${{ inputs.helm-wait }}" == "atomic" ]]; then
+          if [[ "${{ inputs.atomic }}" == true ]]; then
             WAIT_ARG="--atomic"
           fi
           helm upgrade ${{ github.event.repository.name }} ./deployments --install ${WAIT_ARG} --set image.tag="${{ inputs.image_tag }}" -n ${{ inputs.namespace }} ${ARG_VALUES_FILE}

--- a/.github/workflows/helm-deploy.yaml
+++ b/.github/workflows/helm-deploy.yaml
@@ -19,6 +19,11 @@ on:
         description: "Target environment for deployment (stg|prod)"
         required: true
         type: string
+      helm-wait:
+        description: "If set to 'atomic' will use --atomic enabling auto-rollback instead of --wait"
+        default: "wait"
+        required: true
+        type: string
     secrets:
       k8s_server:
         required: true
@@ -48,7 +53,11 @@ jobs:
           if [ ! -z "${{ inputs.values-file }}" ]; then
             ARG_VALUES_FILE="-f ${{ inputs.values-file }}"
           fi
-          helm upgrade ${{ github.event.repository.name }} ./deployments --install --wait --set image.tag="${{ inputs.image_tag }}" -n ${{ inputs.namespace }} ${ARG_VALUES_FILE}
+          WAIT_ARG="--wait"
+          if [ "${{ inputs.helm-wait }}" == "atomic" ]; then
+            WAIT_ARG="--atomic"
+          fi
+          helm upgrade ${{ github.event.repository.name }} ./deployments --install $WAIT_ARG --set image.tag="${{ inputs.image_tag }}" -n ${{ inputs.namespace }} ${ARG_VALUES_FILE}
       - name: Update GitHub release
         if: inputs.environment == 'prod'
         uses: ncipollo/release-action@v1

--- a/.github/workflows/helm-deploy.yaml
+++ b/.github/workflows/helm-deploy.yaml
@@ -22,7 +22,7 @@ on:
       helm-wait:
         description: "If set to 'atomic' will use --atomic enabling auto-rollback instead of --wait"
         default: "wait"
-        required: true
+        required: false
         type: string
     secrets:
       k8s_server:
@@ -54,7 +54,7 @@ jobs:
             ARG_VALUES_FILE="-f ${{ inputs.values-file }}"
           fi
           WAIT_ARG="--wait"
-          if [ "${{ inputs.helm-wait }}" == "atomic" ]; then
+          if [[ "${{ inputs.helm-wait }}" == "atomic" ]]; then
             WAIT_ARG="--atomic"
           fi
           helm upgrade ${{ github.event.repository.name }} ./deployments --install $WAIT_ARG --set image.tag="${{ inputs.image_tag }}" -n ${{ inputs.namespace }} ${ARG_VALUES_FILE}


### PR DESCRIPTION
## Description

`--atomic` implies `--wait` but we'll make it opt-in for the time being. `products-api` for example has some stateful k8s resources and may not want to auto-rollback.

Research would be necessary to understand what a `helm rollback` would do on a pre-repo bases before enabling.