### PR TITLE
feat: configurable php version

### DIFF
--- a/.github/workflows/openapi-generate-php-client.yaml
+++ b/.github/workflows/openapi-generate-php-client.yaml
@@ -2,6 +2,10 @@ name: Openapi Generate PHP Client
 on:
   workflow_call:
     inputs:
+      phpVersion:
+        required: false
+        type: string
+        default: "7.4"
       specLocation:
         description: The filepath to the openapi spec.
         required: false
@@ -94,7 +98,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: ${{ inputs.phpVersion }}
           tools: composer:v2
           coverage: none
       - name: Install dependencies


### PR DESCRIPTION
## Description

We have a generated PHP client that needs Guzzle 7 and PHP `>=8.0`. This PR adds a `phpVersion` input, keeping the default of `7.4` that was previously hard-coded.

Example: https://github.com/encodium/products-api-php8-client/actions/runs/6251488595/job/16972724274
```
Error: Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires php ^8.0 but your php version (7.4.33) does not satisfy that requirement.
  Problem 2
    - illuminate/support[v10.0.0, ..., v10.24.0] require php ^8.1 -> your php version (7.4.33) does not satisfy that requirement.
    - Root composer.json requires illuminate/support ^10.0 -> satisfiable by illuminate/support[v10.0.0, ..., v10.24.0].


  Problem 1
    - Root composer.json requires php ^8.0 but your php version (7.4.33) does not satisfy that requirement.
  Problem 2
    - illuminate/support[v10.0.0, ..., v10.24.0] require php ^8.1 -> your php version (7.4.33) does not satisfy that requirement.
    - Root composer.json requires illuminate/support ^10.0 -> satisfiable by illuminate/support[v10.0.0, ..., v10.24.0].
```