### PR TITLE
feat: calculate branch reusable workflow

### DIFF
--- a/.github/workflows/calculate-branch.yaml
+++ b/.github/workflows/calculate-branch.yaml
@@ -1,0 +1,80 @@
+name: Calculate Branch
+on:
+  workflow_call:
+    inputs:
+      branch:
+        description: The branch name
+        required: true
+        type: string
+      owner:
+        description: The GitHub owner of the repository
+        required: false
+        type: string
+        default: encodium
+      repo:
+        description: The GitHub repository name
+        required: true
+        type: string
+    outputs:
+      branch:
+        description: "The calculated branch"
+        value: ${{ jobs.calculate-branch.outputs.branch }}
+      found:
+        description: "Set to true if the branch was found"
+        value: ${{ jobs.calculate-branch.outputs.found }}
+      sha:
+        description: "The branch SHA hash"
+        value: ${{ jobs.calculate-branch.outputs.sha }}
+      sha_short:
+        description: "The short SHA hash"
+        value: ${{ jobs.calculate-branch.outputs.sha_short }}
+    secrets:
+      github_api_token:
+        required: true
+
+jobs:
+  calculate-branch:
+    name: Calculate Branch
+    runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ steps.calculate_branch.outputs.branch }}
+      found: ${{ steps.calculate_branch.outputs.found }}
+      sha: ${{ steps.calculate_branch.outputs.sha }}
+      sha_short: ${{ steps.calculate_branch.outputs.sha_short }}
+    steps:
+      - name: Calculate Branch
+        id: calculate_branch
+        env:
+          GH_TOKEN: ${{ secrets.github_api_token }}
+        run: |
+          requested_branch="${{ inputs.branch }}"
+          owner="${{ inputs.owner }}"
+          repo="${{ inputs.repo }}"
+
+          echo "Checking to see if the branch \"${requested_branch}\" exists in this project."
+          branch_info=$(gh api "/repos/${owner}/${repo}/branches/${requested_branch}" --jq '{name: .name, sha: .commit.sha}' || echo '{}')
+          branch_name_candidate=$(echo "${branch_info}" | jq -r '.name')
+
+          if [[ "${branch_name_candidate}" == "${requested_branch}" ]];
+          then
+            echo "Branch \"${branch_name_candidate}\" found."
+            branch_name="${branch_name_candidate}"
+            sha=$(echo "${branch_info}" | jq -r '.sha')
+            sha_short=$(echo "${branch_info}" | jq -r '.sha[:7]')
+            found=true
+          else
+            branch_name=""
+            sha=""
+            sha_short=""
+            found=""
+          fi
+
+          echo "Branch name: ${branch_name}"
+          echo "SHA: ${sha}"
+          echo "SHA (short): ${sha_short}"
+          echo "Found: ${found}"
+
+          echo "branch=${branch_name}" >> "$GITHUB_OUTPUT"
+          echo "found=${found}" >> "$GITHUB_OUTPUT"
+          echo "sha=${sha}" >> "$GITHUB_OUTPUT"
+          echo "sha_short=${sha_short}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/calculate-branch.yaml
+++ b/.github/workflows/calculate-branch.yaml
@@ -75,6 +75,6 @@ jobs:
           echo "Found: ${found}"
 
           echo "branch=${branch_name}" >> "$GITHUB_OUTPUT"
-          echo "found=${found}" >> "$GITHUB_OUTPUT"
           echo "sha=${sha}" >> "$GITHUB_OUTPUT"
           echo "sha_short=${sha_short}" >> "$GITHUB_OUTPUT"
+          echo "found=${found}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/calculate-branch.yaml
+++ b/.github/workflows/calculate-branch.yaml
@@ -1,3 +1,9 @@
+# Determine if a given branch exists in a repository
+# Returns the following outputs:
+#  branch: the name of the branch or empty if not found
+#  found: indicates if the branch exists (true or false)
+#  sha: the full SHA or empty if not found
+#  sha_short: the 7-character SHA or empty if not found
 name: Calculate Branch
 on:
   workflow_call:

--- a/.github/workflows/calculate-branch.yaml
+++ b/.github/workflows/calculate-branch.yaml
@@ -66,7 +66,7 @@ jobs:
             branch_name=""
             sha=""
             sha_short=""
-            found=""
+            found=false
           fi
 
           echo "Branch name: ${branch_name}"

--- a/.github/workflows/calculate-branch.yaml
+++ b/.github/workflows/calculate-branch.yaml
@@ -1,4 +1,5 @@
-# Determine if a given branch exists in a repository
+# Determine if a given branch exists in a repository.
+#
 # Returns the following outputs:
 #  branch: the name of the branch or empty if not found
 #  found: indicates if the branch exists (true or false)


### PR DESCRIPTION
## Description

Reusable workflow to validate if a given branch exists in a repo. If the repo contains the branch, the action sends the sha and a short version of the sha as output.

**Jira Issue:** https://revolutionparts.atlassian.net/browse/DEVX-655

## Background
When deploying QA environments, the operator will provide a branch to deploy. Each project in the deployment will build the given branch if it exists, or deploy the `latest` Dockerfile otherwise.

## Testing Information
I am already testing this through internal_api. Here's an action run using this workflow https://github.com/encodium/internal_api/actions/runs/6804578886