### PR TITLE
feat: update php unit test workflow to run in docker

### DIFF
--- a/.github/workflows/php-unit-test.yaml
+++ b/.github/workflows/php-unit-test.yaml
@@ -16,6 +16,10 @@ on:
         type: string
         required: false
         default: "composer test"
+      run_docker:
+        type: boolean
+        required: false
+        default: false
       run_sonar:
         type: boolean
         required: false
@@ -28,6 +32,14 @@ on:
         type: string
         required: false
         default: "phpunit-code-coverage-report"
+      health_check_command:
+        type: string
+        required: false
+        default: null
+      health_check_timeout:
+        type: number
+        required: false
+        default: 300
     secrets:
       packagist_username:
         required: true
@@ -80,6 +92,21 @@ jobs:
           timeout_minutes: 5
           max_attempts: 5
           command: composer install --prefer-dist --no-interaction --no-progress
+      - name: Docker compose pull
+        if: ${{ inputs.run_docker }}
+        run: docker compose --project-directory . pull
+      - name: Docker compose up
+        if: ${{ inputs.run_docker }}
+        run: docker compose --project-directory . up --build -d
+      - name: Wait for docker container to be ready
+        if: ${{ inputs.run_docker }}
+        run: |
+          timeout=${{ inputs.health_check_timeout }}
+          until [ $timeout -eq 0 ] || ${{ inputs.health_check_command }}; do
+            sleep 5
+            timeout=$((timeout-5))
+          done
+          [ $timeout -gt 0 ]
       - name: Execute tests
         run: |
           ${{ inputs.test_command }}


### PR DESCRIPTION
## Description
This change adds additional steps to support running php tests inside of a docker container

**Jira Issue:** https://revolutionparts.atlassian.net/browse/DEVX-700

## Background
Working through changes in the file-scan-daemon, I needed to run tests inside of a docker container. In order to do THAT, I needed a way to run health checks and wait for a docker container to become ready. 

Input Changes:
* `run_docker` - turn on to run tests inside of a docker container
* `health_check_command` - specific to each application, command to run to determine whether the container is ready ([example](https://github.com/encodium/file-scan-daemon/blob/main/.github/workflows/pull-request-workflow.yaml#L28))
* `health_check_timeout` - how many seconds to wait for the container to be ready (defaults to 5 mins)

Workflow Changes:
3 new workflow steps, all gated behind the `run_docker` flag. Most notably, the wait command, which loops through and checks to see whether or not the container is ready to run tests. 

## Testing Information
Battle-Tested this over on the [file-scan-daemon](https://github.com/encodium/file-scan-daemon/blob/main/.github/workflows/pull-request-workflow.yaml#L22) repo, working off a copy that I'm now moving back here. 
