### PR TITLE
fix: do composer require instead of update

### DIFF
--- a/.github/workflows/php-common-bump.yaml
+++ b/.github/workflows/php-common-bump.yaml
@@ -57,7 +57,7 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer update revolutionparts/common --no-dev --prefer-dist --no-interaction --no-progress --optimize-autoloader --apcu-autoloader
+          command: composer require revolutionparts/common --prefer-dist --no-interaction --no-progress --optimize-autoloader --apcu-autoloader
       - name: Commit Common Bump
         run: |
           git config user.name github-actions


### PR DESCRIPTION
## Description
If there are external dependencies in common, `composer update` will silently update to the latest version it can. Changing to `composer require` will make this scenario throw errors so that we know there's a problem