### PR TITLE
chore: upgrade upload-artifact to be compatible with v4

### DIFF
--- a/.github/workflows/php-laravel-test.yaml
+++ b/.github/workflows/php-laravel-test.yaml
@@ -85,7 +85,8 @@ jobs:
           DB_PASSWORD: postgres
 
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
+          include-hidden-files: true
           name: ${{ inputs.coverage_artifact }}
           path: ${{ inputs.coverage_path }}

--- a/.github/workflows/php-stan.yaml
+++ b/.github/workflows/php-stan.yaml
@@ -75,7 +75,8 @@ jobs:
 
       - name: phpstan errors artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
+          include-hidden-files: true
           name: ${{ inputs.artifact_name }}
           path: ${{ inputs.error_file }}

--- a/.github/workflows/php-unit-test.yaml
+++ b/.github/workflows/php-unit-test.yaml
@@ -86,8 +86,9 @@ jobs:
         env:
           COVERAGE_FILE: ${{ inputs.coverage_file }}
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
+          include-hidden-files: true
           name: ${{ inputs.coverage_artifact_name }}
           path: ${{ inputs.coverage_file }}
       - name: Fix code coverage paths


### PR DESCRIPTION
## Description
[v3 is not compatible to v4](https://github.com/actions/toolkit/blob/main/packages/artifact/docs/faq.md#which-versions-of-the-artifacts-packages-are-compatible), which we are now using 