### PR TITLE
feat: added the ability to run tests with docker

### DIFF
--- a/.github/workflows/php-laravel-test.yaml
+++ b/.github/workflows/php-laravel-test.yaml
@@ -16,6 +16,10 @@ on:
         type: string
         required: false
         default: "composer test"
+      run_docker:
+        type: boolean
+        required: false
+        default: false
       coverage_path:
         description: "The artifact path for coverage reports"
         type: string
@@ -26,6 +30,14 @@ on:
         type: string
         required: false
         default: "code-coverage-report"
+      health_check_command:
+        type: string
+        required: false
+        default: null
+      health_check_timeout:
+        type: number
+        required: false
+        default: 300
     secrets:
       packagist_username:
         required: true
@@ -78,6 +90,22 @@ jobs:
                 }
               }
             }
+      
+      - name: Docker compose pull
+        if: ${{ inputs.run_docker }}
+        run: docker compose --project-directory . pull
+      - name: Docker compose up
+        if: ${{ inputs.run_docker }}
+        run: docker compose --project-directory . up --build -d
+      - name: Wait for docker container to be ready
+        if: ${{ inputs.run_docker }}
+        run: |
+          timeout=${{ inputs.health_check_timeout }}
+          until [ $timeout -eq 0 ] || ${{ inputs.health_check_command }}; do
+            sleep 5
+            timeout=$((timeout-5))
+          done
+          [ $timeout -gt 0 ]
 
       - name: Execute tests
         run: ${{ inputs.test_command }}

--- a/.github/workflows/php-laravel-test.yaml
+++ b/.github/workflows/php-laravel-test.yaml
@@ -86,16 +86,6 @@ jobs:
       - name: Run Docker Command
         if: ${{ inputs.docker_command != '' }}
         run: ${{ inputs.docker_command }}
-      - name: Wait for docker container to be ready
-        if: ${{ inputs.run_docker }}
-        run: |
-          timeout=${{ inputs.health_check_timeout }}
-          until [ $timeout -eq 0 ] || ${{ inputs.health_check_command }}; do
-            sleep 5
-            timeout=$((timeout-5))
-          done
-          [ $timeout -gt 0 ]
-
       - name: Execute tests
         run: ${{ inputs.test_command }}
         env:

--- a/.github/workflows/php-laravel-test.yaml
+++ b/.github/workflows/php-laravel-test.yaml
@@ -16,10 +16,6 @@ on:
         type: string
         required: false
         default: "composer test"
-      run_docker:
-        type: boolean
-        required: false
-        default: false
       coverage_path:
         description: "The artifact path for coverage reports"
         type: string
@@ -30,14 +26,10 @@ on:
         type: string
         required: false
         default: "code-coverage-report"
-      health_check_command:
+      docker_command:
         type: string
         required: false
-        default: null
-      health_check_timeout:
-        type: number
-        required: false
-        default: 300
+        default: ""
     secrets:
       packagist_username:
         required: true
@@ -91,12 +83,9 @@ jobs:
               }
             }
       
-      - name: Docker compose pull
-        if: ${{ inputs.run_docker }}
-        run: docker compose --project-directory . pull
-      - name: Docker compose up
-        if: ${{ inputs.run_docker }}
-        run: docker compose --project-directory . up --build -d
+      - name: Run Docker Command
+        if: ${{ inputs.docker_command != '' }}
+        run: ${{ inputs.docker_command }}
       - name: Wait for docker container to be ready
         if: ${{ inputs.run_docker }}
         run: |


### PR DESCRIPTION
## Description
Parameterized the `php-laravel-test` workflow to allow running tests after starting the docker setup. This allows to connect to the local database setup similar to dev.  See commit https://github.com/encodium/nexus/pull/65/commits/fd8bd9cd38083f2e1b3f90b1bd05a9d0748eb899 for how this is being used in `nexus`.

This pull-request is modeled along the lines of https://github.com/encodium/.github/pull/71

**Related PRs:**
- https://github.com/encodium/nexus/pull/65

**Jira Issue:** https://revolutionparts.atlassian.net/browse/INT-1624

## Background
Feature tests require local database to be running as there is no mocking involved and executes the real SQL statements as in dev/prod.

## Testing Information
To be tested after merging this change with the related nexus PR.