### PR TITLE
[DEVEX-1204] Add conditional build flags for app and webserver images

### DIFF
--- a/.github/workflows/php-laravel-build-push.yaml
+++ b/.github/workflows/php-laravel-build-push.yaml
@@ -17,11 +17,21 @@ on:
         required: false
         type: string
         default: "./build/Dockerfile-app"
+      build_app_image:
+        description: "Whether to build the application (PHP-FPM) image"
+        required: false
+        type: boolean
+        default: true
       build_cli_image:
         description: "Whether to build the CLI image"
         required: false
         type: boolean
         default: false
+      build_webserver_image:
+        description: "Whether to build the webserver (nginx) image"
+        required: false
+        type: boolean
+        default: true
       dockerfile_cli_path:
         description: "Path to the CLI dockerfile you want to build"
         required: false
@@ -45,6 +55,7 @@ on:
 
 jobs:
   build-and-push-app-image:
+    if: ${{ inputs.build_app_image }}
     runs-on: ubuntu-latest
     name: Build + Push Application Image
     steps:
@@ -110,6 +121,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
   build-and-push-webserver-image:
+    if: ${{ inputs.build_webserver_image }}
     runs-on: ubuntu-latest
     name: Build + Push Webserver (e.g. nginx) Image
     steps:


### PR DESCRIPTION
## Summary

- Adds `build_app_image` (default `true`) and `build_webserver_image` (default `true`) input flags to `php-laravel-build-push.yaml`
- Adds `if:` conditions to `build-and-push-app-image` and `build-and-push-webserver-image` jobs, matching the existing `build_cli_image` pattern
- Fully backward-compatible: existing callers don't pass these inputs, so they default to `true` (unchanged behavior)

## Context

[DEVEX-1204](https://revolutionparts.atlassian.net/browse/DEVEX-1204)

CLI-only repos (like `marketplaces`) don't have `Dockerfile-app` or `Dockerfile-nginx`. The merge-to-main workflow fails with `open Dockerfile-app: no such file or directory` because the app and webserver jobs always run unconditionally. The CLI job already had a `build_cli_image` toggle — this PR adds the same pattern for the other two jobs.

## Test plan

- [ ] Existing repos (e.g., `listings`) that don't pass the new inputs should build all three images as before (defaults are `true`)
- [ ] CLI-only repos (e.g., `marketplaces`) can pass `build_app_image: false` and `build_webserver_image: false` to skip those jobs
- [ ] Verify the skipped jobs show as "skipped" in the Actions UI (not failed)

Made with [Cursor](https://cursor.com)

[DEVEX-1204]: https://revolutionparts.atlassian.net/browse/DEVEX-1204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ