### PR TITLE
fix(ci): ensure ext-redis >= 6.1 before composer in PHPStan workflow

### DIFF
--- a/.github/workflows/php-stan.yaml
+++ b/.github/workflows/php-stan.yaml
@@ -51,6 +51,7 @@ jobs:
           coverage: none
           php-version: ${{ inputs.php_version }}
           tools: composer
+          extensions: mbstring, xml, curl, redis
         env:
           COMPOSER_AUTH_JSON: |
             {
@@ -61,6 +62,21 @@ jobs:
                 }
               }
             }
+
+      # symfony/cache 7.4+ conflicts with ext-redis < 6.1; GitHub images may ship 5.x
+      - name: Ensure ext-redis >= 6.1
+        shell: bash
+        run: |
+          set -euo pipefail
+          if php -r 'exit(version_compare(phpversion("redis") ?: "0", "6.1.0", ">=") ? 0 : 1);'; then
+            php -r 'echo "ext-redis ".phpversion("redis")." OK\n";'
+            exit 0
+          fi
+          echo "ext-redis $(php -r 'echo phpversion("redis") ?: "missing";') is below 6.1; upgrading via PECL"
+          sudo pecl uninstall -r redis 2>/dev/null || true
+          printf '\n' | sudo pecl install redis
+          php -r 'if (version_compare(phpversion("redis") ?: "0", "6.1.0", "<")) { fwrite(STDERR, "ext-redis still < 6.1 after PECL install\n"); exit(1); }'
+          php -r 'echo "ext-redis ".phpversion("redis")." OK\n";'
 
       - name: Install composer dependencies
         uses: ramsey/composer-install@v2
@@ -78,7 +94,7 @@ jobs:
         run: ${{ inputs.command }}
         env:
           PHPSTAN_ERROR_FILE: ${{ inputs.error_file }}
-      
+
       - name: Cache PHPStan Results
         if: always()
         uses: actions/cache/save@v4


### PR DESCRIPTION
## Context

`symfony/cache` v7.4+ declares a conflict with `ext-redis` &lt; 6.1. GitHub-hosted runners often ship the PHP redis extension 5.x, so `composer install` fails the platform check before PHPStan runs.

## Changes

- Enable common extensions including `redis` in `setup-php`.
- Add a step that upgrades via PECL when `phpversion('redis')` &lt; 6.1.0, before `ramsey/composer-install`.

Consumers (e.g. webstore `phpstan.yaml`) pick this up after merge when pinned to `@main`.