### PR TITLE
fix(ci): pin PECL redis 6.3.0 in setup-php for PHPStan workflow

### DIFF
--- a/.github/workflows/php-stan.yaml
+++ b/.github/workflows/php-stan.yaml
@@ -51,6 +51,8 @@ jobs:
           coverage: none
           php-version: ${{ inputs.php_version }}
           tools: composer
+          # symfony/cache 7.4+ conflicts with ext-redis < 6.1; pin PECL version (see setup-php wiki)
+          extensions: mbstring, xml, curl, redis-6.3.0
         env:
           COMPOSER_AUTH_JSON: |
             {


### PR DESCRIPTION
## Context

`symfony/cache` 7.4+ conflicts with `ext-redis` &lt; 6.1. Pin the PECL extension via [shivammathur/setup-php extension versions](https://github.com/shivammathur/setup-php/wiki/Add-extension-from-PECL-with-libraries-and-custom-configuration) (`redis-6.3.0`) instead of extra CI scripts.

## Consumer

Webstore and other repos using `encodium/.github/.github/workflows/php-stan.yaml@main` pick this up after merge.

Closes / supersedes the bash-based approach from #109 if that was still open.