### PR TITLE
DEVEX-1087: fix promote-release-candidate release-action commitish

### DIFF
--- a/.github/workflows/promote-release-candidate.yaml
+++ b/.github/workflows/promote-release-candidate.yaml
@@ -62,12 +62,13 @@ jobs:
               exit 1
             fi
           fi
-          if ! git rev-parse "$TAG" >/dev/null 2>&1; then
+          if ! SHA=$(git rev-parse "$TAG" 2>/dev/null); then
             echo "::error::Tag '$TAG' does not exist"
             exit 1
           fi
           echo "source_tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "Resolved source tag: $TAG"
+          echo "source_sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "Resolved source tag: $TAG ($SHA)"
       - name: Compute pretty version
         id: compute
         env:
@@ -136,7 +137,7 @@ jobs:
         with:
           token: ${{ secrets.repo_write_pat }}
           tag: ${{ steps.compute.outputs.pretty_tag }}
-          commit: ${{ steps.resolve.outputs.source_tag }}
+          commit: ${{ steps.resolve.outputs.source_sha }}
           name: Release Candidate ${{ steps.compute.outputs.pretty_tag }}
           body: "Promoted from `${{ steps.resolve.outputs.source_tag }}`."
           prerelease: true


### PR DESCRIPTION
The `promote-release-candidate` reusable workflow fails at the final `ncipollo/release-action` step with:

```
422 Validation Failed: target_commitish invalid
```

Root cause: we pass the source tag name (e.g. `v0.33.1-main.1`) as the action's `commit:` input, which maps to GitHub's `target_commitish` API field. That field only accepts branch names or commit SHAs — not tag names.

Fix: resolve the source tag to its commit SHA in the `Resolve source tag` step (via `git rev-parse`) and pass the SHA to the release action instead.

First hit on catalog_api: https://github.com/encodium/catalog_api/actions/runs/24678268811/job/72168232890

Part of DEVEX-1087.