### PR TITLE
DEVEX-1087: handle annotated -main tags in promote-release-candidate

### DIFF
--- a/.github/workflows/promote-release-candidate.yaml
+++ b/.github/workflows/promote-release-candidate.yaml
@@ -62,7 +62,10 @@ jobs:
               exit 1
             fi
           fi
-          if ! SHA=$(git rev-parse "$TAG" 2>/dev/null); then
+          # '^{commit}' dereferences annotated tags to their target commit;
+          # for lightweight tags this is a no-op. Branch refs must point to
+          # commits, not tag objects, so the commit SHA is what we push.
+          if ! SHA=$(git rev-parse "$TAG^{commit}" 2>/dev/null); then
             echo "::error::Tag '$TAG' does not exist"
             exit 1
           fi
@@ -99,12 +102,12 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-      - name: Reset target branch to source tag
+      - name: Reset target branch to source commit
         env:
-          SRC: ${{ steps.resolve.outputs.source_tag }}
+          SHA: ${{ steps.resolve.outputs.source_sha }}
           TARGET: ${{ inputs.target_branch }}
         run: |
-          git push origin "+refs/tags/$SRC:refs/heads/$TARGET"
+          git push origin "+$SHA:refs/heads/$TARGET"
       - name: Login to container registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
Fixes `[remote rejected]` failures on the "Reset target branch" step when the `-main.N` tag is annotated.

## Root cause

`mathieudutour/github-tag-action` can produce either lightweight or annotated tags. When annotated:

- `git rev-parse TAG` returns the **tag object** SHA, not the commit
- `git push +refs/tags/TAG:refs/heads/rc` tries to set a branch ref to the tag object
- GitHub rejects this because branch refs must point to commits

Catalog_api happened to have lightweight `-main` tags, so the bug was invisible until we rolled out to rp_api, checkout, and internal_api (which have annotated `-main` tags).

## Fix

1. Resolve via `git rev-parse TAG^{commit}` (no-op for lightweight, dereferences annotated)
2. Push the commit SHA directly (`+$SHA:refs/heads/rc`) instead of the tag ref

## Observed in

- encodium/rp_api run 24679969202
- encodium/checkout run 24679989169  
- encodium/internal_api (after re-run picked up the fresh `-main` tag)

Part of DEVEX-1087.