### PR TITLE
DEVEX-1087: additional_image_refs for profiler variants in promote-release-candidate

### DIFF
--- a/.github/workflows/promote-release-candidate.yaml
+++ b/.github/workflows/promote-release-candidate.yaml
@@ -21,6 +21,16 @@ on:
         required: false
         default: "rc"
         type: string
+      additional_image_refs:
+        description: >
+          JSON array of full image references (with `{tag}` placeholder) to
+          retag in addition to the `image_tag_prefixes` above. Use this for
+          images that don't live at the caller repo's own registry path — for
+          example, `-profiler` variants published to a separate image name.
+          Example: '["ghcr.io/owner/repo-profiler:{tag}"]'
+        required: false
+        default: "[]"
+        type: string
     secrets:
       repo_write_pat:
         description: "PAT with contents:write for force-pushing the target branch and pushing tags"
@@ -123,6 +133,7 @@ jobs:
           SRC: ${{ steps.resolve.outputs.source_tag }}
           PRETTY: ${{ steps.compute.outputs.pretty_tag }}
           PREFIXES_JSON: ${{ inputs.image_tag_prefixes }}
+          ADDITIONAL_JSON: ${{ inputs.additional_image_refs }}
         run: |
           count=$(echo "$PREFIXES_JSON" | jq 'length')
           if [ "$count" -eq 0 ]; then
@@ -134,6 +145,13 @@ jobs:
             docker buildx imagetools create \
               --tag "$REGISTRY/$IMAGE_NAME:${prefix}${PRETTY}" \
               "$REGISTRY/$IMAGE_NAME:${prefix}${SRC}"
+          done
+          echo "$ADDITIONAL_JSON" | jq -r '.[]' | while IFS= read -r template; do
+            [ -z "$template" ] && continue
+            src_ref="${template//\{tag\}/$SRC}"
+            dst_ref="${template//\{tag\}/$PRETTY}"
+            echo "Retagging (additional) $src_ref -> $dst_ref"
+            docker buildx imagetools create --tag "$dst_ref" "$src_ref"
           done
       - name: Create pretty tag and GitHub release
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
Adds an optional `additional_image_refs` input to the reusable workflow so profiler (and any future variant) images published to a separate image name can be retagged alongside the main images during release candidate promotion.

## Why

`image_tag_prefixes` only supports tag prefixes on the caller repo's own registry path (`ghcr.io/owner/repo:PREFIX-TAG`). Several services publish profiler variants to a distinct image name instead:

- `ghcr.io/encodium/rp_api-profiler:TAG`
- `ghcr.io/encodium/webstore-profiler:TAG`
- `ghcr.io/encodium/internal_api-profiler:TAG`

Without this, profiler images stay pinned to `-main.N` versions and drift from the promoted RC — QA runs using profiler get a different image than the RC everyone else deploys.

## How

Takes a JSON array of full image refs with a `{tag}` placeholder:

```yaml
additional_image_refs: '["ghcr.io/encodium/webstore-profiler:{tag}"]'
```

For each template, the retag step substitutes `{tag}` with the source and pretty tags and runs `docker buildx imagetools create`. No rebuild. Defaults to empty, so existing callers (catalog_api, accounts-api, etc.) are unaffected.

## Follow-ups

Once merged, wrappers in `webstore`, `rp_api`, and `internal_api` get updated to pass their profiler image refs. I'll open those as follow-up PRs.

Part of DEVEX-1087.