### PR TITLE
DEVEX-1087: auto-clear stuck pending helm releases before upgrade

### DIFF
--- a/.github/workflows/helm-deploy-eks.yaml
+++ b/.github/workflows/helm-deploy-eks.yaml
@@ -95,6 +95,18 @@ jobs:
           if [ ! -z "${{ inputs.release_name }}" ]; then
             RELEASE_NAME="${{ inputs.release_name }}"
           fi
+
+          # If a prior run was cancelled mid-upgrade, the release may be stuck
+          # in a 'pending' status that blocks all subsequent operations. Detect
+          # and clear it before proceeding so we don't require manual intervention.
+          STATUS=$(helm status "${RELEASE_NAME}" -n "${{ inputs.namespace }}" -o json 2>/dev/null | jq -r '.info.status' || echo "none")
+          case "$STATUS" in
+            pending-install|pending-upgrade|pending-rollback)
+              echo "::warning::Release '${RELEASE_NAME}' stuck in '${STATUS}' (likely from a cancelled prior run); rolling back before upgrade."
+              helm rollback "${RELEASE_NAME}" 0 -n "${{ inputs.namespace }}" || helm uninstall "${RELEASE_NAME}" -n "${{ inputs.namespace }}"
+              ;;
+          esac
+
           helm upgrade -i ${RELEASE_NAME} ./deployments --install ${WAIT_ARG} ${TIMEOUT_ARG} --set image.tag="${{ inputs.image_tag }}" -n ${{ inputs.namespace }} ${ARG_VALUES_FILE}
       - name: Update GitHub release
         if: inputs.environment == 'prod'


### PR DESCRIPTION
## Problem

When a `helm-deploy-eks` run is cancelled mid-upgrade (e.g. the workflow is cancelled before helm's client-side operation completes), the release state on the cluster stays as `pending-install`, `pending-upgrade`, or `pending-rollback`. All subsequent deploys fail with:

```
Error: UPGRADE FAILED: another operation (install/upgrade/rollback) is in progress
```

…until someone manually `helm rollback` or `helm uninstall`.

Observed today on rp_api QA after a cancelled Start Release Train run.

## Fix

Before running `helm upgrade`, check the release status. If it's in any of the pending states, attempt `helm rollback RELEASE 0` (roll back to the previous known-good revision); fall back to `helm uninstall` if rollback isn't possible (e.g. no prior revision exists). Emit a workflow warning annotation so the intervention is visible.

## Effect

Any caller of `helm-deploy-eks` benefits automatically — no per-repo change needed.

Drafted for review; happy to pair on edge cases before un-drafting.