### PR TITLE
DEVEX-1087: sync CDN assets during release candidate promotion

### DIFF
--- a/.github/workflows/promote-release-candidate.yaml
+++ b/.github/workflows/promote-release-candidate.yaml
@@ -31,6 +31,16 @@ on:
         required: false
         default: "[]"
         type: string
+      sync_cdn_assets:
+        description: >
+          If true, sync the repo's CDN assets from the source tag path to the
+          pretty tag path under `s3://<cdn_bucket>/<repo_name>/`. Required when
+          the caller's Build workflow uploads tag-versioned JS/CSS assets to
+          S3 (e.g. webstore, checkout, manage), so promoted deployments can
+          resolve the same assets at the new pretty tag path.
+        required: false
+        default: false
+        type: boolean
     secrets:
       repo_write_pat:
         description: "PAT with contents:write for force-pushing the target branch and pushing tags"
@@ -38,6 +48,15 @@ on:
       gh_token:
         description: "PAT with packages:write on the caller repo's container registry (used to retag images)"
         required: true
+      cdn_bucket:
+        description: "S3 bucket name holding the caller's CDN assets. Required only when sync_cdn_assets=true."
+        required: false
+      cdn_aws_access_id:
+        description: "AWS access key for the CDN bucket. Required only when sync_cdn_assets=true."
+        required: false
+      cdn_aws_access_secret:
+        description: "AWS secret key for the CDN bucket. Required only when sync_cdn_assets=true."
+        required: false
     outputs:
       source_tag:
         description: "The -main.N tag that was promoted"
@@ -153,6 +172,25 @@ jobs:
             echo "Retagging (additional) $src_ref -> $dst_ref"
             docker buildx imagetools create --tag "$dst_ref" "$src_ref"
           done
+      - name: Sync CDN assets
+        if: inputs.sync_cdn_assets
+        env:
+          BUCKET: ${{ secrets.cdn_bucket }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          SRC: ${{ steps.resolve.outputs.source_tag }}
+          PRETTY: ${{ steps.compute.outputs.pretty_tag }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.cdn_aws_access_id }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.cdn_aws_access_secret }}
+          AWS_DEFAULT_REGION: us-east-1
+        run: |
+          if [ -z "$BUCKET" ] || [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+            echo "::error::sync_cdn_assets=true requires cdn_bucket, cdn_aws_access_id, and cdn_aws_access_secret secrets."
+            exit 1
+          fi
+          SRC_PATH="s3://${BUCKET}/${REPO_NAME}/${SRC}/"
+          DST_PATH="s3://${BUCKET}/${REPO_NAME}/${PRETTY}/"
+          echo "Syncing CDN assets ${SRC_PATH} -> ${DST_PATH}"
+          aws s3 sync "$SRC_PATH" "$DST_PATH"
       - name: Create pretty tag and GitHub release
         uses: ncipollo/release-action@v1
         with:


### PR DESCRIPTION
## Problem

Services that ship tag-versioned JS/CSS assets (webstore, checkout, manage) upload them during `Build` to `s3://<cdn-bucket>/<repo>/<TAG>/` where `TAG` is the `-main.N` tag. After promotion, the docker image is retagged `v1.5.0-main.3 → v1.5.0` (no rebuild), but the helm chart passes `image.tag` into the running app as `package_version`. The app builds CDN URLs like `<cdn>/<repo>/<package_version>/*` — pointing at a pretty-tag path that does not exist in S3.

Observed on webstore QA today: promoted `v0.405.0`, app tried to load `.../webstore/v0.405.0/*.css` → 404.

## Fix

Add an optional `sync_cdn_assets` boolean input plus three optional secrets (`cdn_bucket`, `cdn_aws_access_id`, `cdn_aws_access_secret`). When enabled, the reusable runs:

```
aws s3 sync s3://<cdn_bucket>/<repo>/<source_tag>/ s3://<cdn_bucket>/<repo>/<pretty_tag>/
```

Server-side copy, preserves Content-Encoding and Cache-Control metadata set at Build time. Takes seconds.

## Callers

- webstore — sync_cdn_assets=true
- checkout — sync_cdn_assets=true
- manage — sync_cdn_assets=true

Wrapper PRs will follow in each of those repos.

## Trade-off considered

Retag-without-rebuild (our current design) sacrifices automatic re-upload of tag-pathed side artifacts. Alternatives were discussed:

- Rebuild on promote — simplest but loses speed and image identity guarantee
- Decouple asset_version from image.tag in helm — requires per-repo helm + app changes

The S3 sync keeps the complexity contained to the reusable and 3 thin wrappers, with no app/helm edits.

Part of DEVEX-1087.