### PR TITLE
feat(php-laravel-build-push): switch image cache from GHA to registry

### DIFF
--- a/.github/workflows/php-laravel-build-push.yaml
+++ b/.github/workflows/php-laravel-build-push.yaml
@@ -107,8 +107,8 @@ jobs:
           file: ${{ inputs.dockerfile_app_path }}
           platforms: linux/amd64
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.new_tag }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
   build-and-push-webserver-image:
     runs-on: ubuntu-latest
     name: Build + Push Webserver (e.g. nginx) Image
@@ -134,8 +134,8 @@ jobs:
           file: ${{ inputs.dockerfile_webserver_path }}
           platforms: linux/amd64
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:webserver-${{ inputs.new_tag }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:webserver-latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-webserver
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-webserver,mode=max
   build-and-push-cli-image:
     if: ${{ inputs.build_cli_image }}
     runs-on: ubuntu-latest
@@ -199,5 +199,5 @@ jobs:
           file: ${{ inputs.dockerfile_cli_path }}
           platforms: linux/amd64
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cli-${{ inputs.new_tag }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cli-latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-cli
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-cli,mode=max


### PR DESCRIPTION
## Summary

The GHA cache backend has a 10GB cap and parallel-job writes were evicting the heavy PHP base layer (apk + pecl + intl compile, ~145s) before the next build could read it — so app builds in `encodium/shopping` (and presumably webstore/internal_api) consistently took 4+ minutes with `#11 [base 2/6] DONE 144.1s` and never `CACHED`.

This switches all three image builds (app/webserver/cli) to a registry-cache backend in the **calling repo's** GHCR namespace via `${{ github.repository }}`. No per-consumer config needed — it works automatically across every repo that uses this workflow.

Cache tags (distinct so the three images don't clobber each other):

- App: `:buildcache`
- Webserver: `:buildcache-webserver`
- CLI: `:buildcache-cli`

## Behavior change for consumers

- **First build after merge per repo**: cold (no cache), no slower than today.
- **Steady state**: should drop several minutes off PHP-heavy builds.
- Each consumer repo gains a `:buildcache*` package tag in GHCR (visibility inherits the repo's). Existing `docker/login-action` and `Packages: write` token cover both push and pull — no permission changes.
- The old GHA cache entries will age out naturally (no manual cleanup).

## Test plan

- [ ] Merge → confirm next build in `encodium/shopping` warms the registry cache (will be cold first time, slow as today)
- [ ] Following push to `encodium/shopping` main → confirm `#11 ... CACHED` for the apk/pecl base layer and total app-image build < 1 minute
- [ ] Spot-check a webstore or internal_api build for the same pattern
- [ ] Confirm `ghcr.io/encodium/<repo>:buildcache` appears as a package on the repo