### PR TITLE
feat(php-builds): switch image cache from GHA to registry

### DIFF
--- a/.github/workflows/php-build-push.yaml
+++ b/.github/workflows/php-build-push.yaml
@@ -100,5 +100,5 @@ jobs:
           platforms: linux/amd64
           target: ${{ inputs.build_target }}
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.tag }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max

--- a/.github/workflows/php-cli-build-push.yaml
+++ b/.github/workflows/php-cli-build-push.yaml
@@ -89,5 +89,5 @@ jobs:
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.new_tag }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           build-args: |
             BUILD_VERSION=${{ inputs.new_tag }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-cli
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-cli,mode=max

--- a/.github/workflows/php-nginx-build-push.yaml
+++ b/.github/workflows/php-nginx-build-push.yaml
@@ -56,5 +56,5 @@ jobs:
           push: true
           platforms: linux/amd64
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:nginx-${{ inputs.tag }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-nginx
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-nginx,mode=max


### PR DESCRIPTION
## Summary
- Applies the same registry-cache pattern from #117 to the remaining PHP docker build workflows: `php-build-push.yaml`, `php-cli-build-push.yaml`, `php-nginx-build-push.yaml`.
- Each workflow gets a per-variant cache tag (`:buildcache`, `:buildcache-cli`, `:buildcache-nginx`) so they can coexist in a single repo without colliding.

## Test plan
- [ ] Verify a downstream repo consuming `php-build-push.yaml` builds successfully and produces a `:buildcache` tag in GHCR
- [ ] Verify `php-cli-build-push.yaml` produces `:buildcache-cli`
- [ ] Verify `php-nginx-build-push.yaml` produces `:buildcache-nginx`
- [ ] Confirm subsequent runs hit the registry cache (faster build times like #117)