### PR TITLE
chore: downgrade golangci-lint version

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          version: 2.11.4
           args: --output.text.print-issued-lines -c ./.golangci.yml --max-same-issues 0 -v --timeout 5m
       - name: Go Generate
         run: go generate ./... && git diff --exit-code

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: 2.11.4
+          version: v2.11.4
           args: --output.text.print-issued-lines -c ./.golangci.yml --max-same-issues 0 -v --timeout 5m
       - name: Go Generate
         run: go generate ./... && git diff --exit-code


### PR DESCRIPTION
## Description
Downgrading the glangci-lint version from 2.12.0 (released today) to 2.11.4
**Jira Issue:** https://revolutionparts.atlassian.net/browse/<issue>

## Background
2.12.0 is far more aggressive with linting than 2.11.4 and the lint failures are blocking a P0 fix from going out

## Testing Information
<!--
Please describe in detail how you tested your changes. Steps to Reproduce, etc.
This section should be thorough enough that reviewers can replicate the testing.
-->

<!--
## Sonar Test Coverage
If your PR does not pass the SonarCloud Code Analysis, describe why it cannot pass before merging.
-->
<!--
For more information about creating PRs: https://revolutionparts.slite.com/app/docs/wLef9fVzlT0MDA/Creating-Pull-Requests
-->