### PR TITLE
DEVEX-1087: fix common bump failing when already up to date

### DIFF
--- a/.github/workflows/php-common-bump.yaml
+++ b/.github/workflows/php-common-bump.yaml
@@ -68,7 +68,7 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer require revolutionparts/common --prefer-dist --no-interaction --no-progress --optimize-autoloader --apcu-autoloader
+          command: composer update revolutionparts/common --prefer-dist --no-interaction --no-progress --optimize-autoloader --apcu-autoloader
       - name: Commit Common Bump
         id: commit
         run: |


### PR DESCRIPTION
## Summary
- Changes `composer require` to `composer update` in php-common-bump.yaml
- `composer update` exits 0 when the package is already at the latest version
- The commit step already handles the no-changes case (skips commit/push)
- Eliminates false-failure red marks in CI when there's nothing to update

## Test plan
- [ ] Merge and verify next common bump on a repo that's already current shows green