### PR TITLE
[DEVEX-1523] Add shared Claude AI code review reusable workflow

### DIFF
--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -1,0 +1,71 @@
+name: Claude AI Code Review
+on:
+  workflow_call:
+    inputs:
+      review_rules:
+        description: "Repo-specific review rules/context to append to prompt"
+        required: false
+        type: string
+        default: ""
+      model:
+        description: "Claude model to use"
+        required: false
+        type: string
+        default: "claude-sonnet-4-6"
+      max_turns:
+        description: "Max conversation turns"
+        required: false
+        type: number
+        default: 5
+    secrets:
+      anthropic_api_key:
+        required: true
+      ai_reviewer_github_token:
+        required: true
+
+jobs:
+  ai-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.anthropic_api_key }}
+          github_token: ${{ secrets.ai_reviewer_github_token }}
+          prompt: |
+            You are a conservative AI code reviewer for an eCommerce platform (PHP, Laravel, TypeScript, React, AWS, k8s).
+
+            ## What to Review
+            - Correctness and logic errors
+            - Security vulnerabilities (SQL injection, XSS, auth bypass, data exposure)
+            - Data integrity risks (wrong column, missing validation, silent data loss)
+            - Race conditions or concurrency issues
+            - Breaking changes to public APIs or interfaces
+
+            ## What NOT to Review
+            - Code style or formatting (linters handle this)
+            - Missing comments or documentation
+            - Naming preferences
+            - Test coverage quantity
+
+            ## Decision: APPROVE or COMMENT
+            Submit an APPROVE review ONLY when ALL of these are true:
+            1. Zero security concerns
+            2. Zero correctness bugs
+            3. Zero data integrity risks
+            4. The change is low-risk: config change, dependency bump, small feature, test-only, docs, refactor with no behavioral change, template/view-only change
+            5. You have zero inline comments to leave
+
+            If ANY concern exists, submit a COMMENT review (never REQUEST_CHANGES). Post your findings as inline comments on the relevant lines. Let the human team make the final call.
+
+            ${{ inputs.review_rules }}
+          claude_args: >-
+            --max-turns ${{ inputs.max_turns }}
+            --model ${{ inputs.model }}
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr review:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## Summary

- Adds `claude-review.yaml` reusable workflow wrapping `anthropics/claude-code-action@v1`
- Reviews PRs for correctness, security vulnerabilities, data integrity risks, race conditions, and breaking API changes
- Supports configurable model, max turns, and repo-specific review rules via inputs
- Auto-approves low-risk changes; posts inline comments (never REQUEST_CHANGES) for concerns

**JIRA:** DEVEX-1523

**Dependency:** Merge the terraform PR first (creates the `ai-reviewer` team and machine user).

Made with [Cursor](https://cursor.com)