### PR TITLE
[DEVEX-1523] Stop AI auto-approvals; comment-only with first-time Slack ping

### DIFF
--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -28,7 +28,7 @@ on:
         type: number
         default: 30
       slack_channel:
-        description: "Optional Slack channel (e.g. '#dev-account-experience-4all') to notify when the AI auto-approves a PR. Requires slack_bot_token secret."
+        description: "Optional Slack channel (e.g. '#dev-account-experience-4all') to notify the first time the AI would have approved a PR (candidate for a quick human review). Requires slack_bot_token secret."
         required: false
         type: string
         default: ""
@@ -174,7 +174,7 @@ jobs:
             }
 
             ## Decision rules
-            - `approve` — Use ONLY if ALL of the following hold:
+            - `approve` — Use ONLY if ALL of the following hold. NOTE: this verdict does NOT cause a formal GitHub approval. The workflow posts a comment review on your behalf saying "I would have approved this PR for the following reasons", which flags the PR as a candidate for a quick human review. Human approval is always required.
               1. You have zero new concerns AND you posted zero inline comments in this run.
               2. The change is low-risk: not touching auth, sessions, billing, encryption, migrations, public APIs, or shared infrastructure/middleware.
               3. You can name a CONCRETE reason it is safe — specific files touched, behavior preserved, and which tests exercise the change. Generic justifications like "looks fine", "no issues found", or "low risk" are NOT acceptable.
@@ -236,7 +236,7 @@ jobs:
           verdict_file="$RUNNER_TEMP/ai-review/verdict.json"
           body_file="$RUNNER_TEMP/ai-review/body.md"
           reasoning_file="$RUNNER_TEMP/ai-review/reasoning.txt"
-          echo "did_approve=false" >> "$GITHUB_OUTPUT"
+          echo "would_have_approved=false" >> "$GITHUB_OUTPUT"
 
           # Resolve decision + reasoning. All failure paths fall through to the case
           # statement as `defer` so the check publishing step gets a clean signal.
@@ -291,17 +291,22 @@ jobs:
 
           case "$decision" in
             approve)
+              # The first line "AI Review: Would have approved" is a stable marker used
+              # by the Slack step to dedupe notifications across re-runs of this PR.
+              # Do NOT change the prefix without updating that step too.
               {
-                echo "AI Review: Approved"
+                echo "AI Review: Would have approved — human review still required."
                 echo ""
-                echo "**Reasoning:** $reasoning"
+                echo "I would have approved this PR for the following reasons:"
+                echo ""
+                echo "$reasoning"
               } > "$body_file"
-              gh pr review "$PR_NUMBER" --repo "$REPO" --approve --body-file "$body_file"
-              echo "did_approve=true" >> "$GITHUB_OUTPUT"
+              gh pr review "$PR_NUMBER" --repo "$REPO" --comment --body-file "$body_file"
+              echo "would_have_approved=true" >> "$GITHUB_OUTPUT"
               echo "conclusion=success" >> "$GITHUB_OUTPUT"
-              echo "title=Approved by AI reviewer" >> "$GITHUB_OUTPUT"
+              echo "title=AI would have approved" >> "$GITHUB_OUTPUT"
               echo "" >> "$GITHUB_STEP_SUMMARY"
-              echo "Posted **approval**. Reasoning: $reasoning" >> "$GITHUB_STEP_SUMMARY"
+              echo "Posted **would-have-approved** comment. Reasoning: $reasoning" >> "$GITHUB_STEP_SUMMARY"
               ;;
             comment)
               {
@@ -329,8 +334,8 @@ jobs:
               ;;
           esac
 
-      - name: Notify Slack on approval
-        if: steps.apply.outputs.did_approve == 'true' && inputs.slack_channel != ''
+      - name: Notify Slack first time AI would have approved
+        if: steps.apply.outputs.would_have_approved == 'true' && inputs.slack_channel != ''
         env:
           SLACK_CHANNEL: ${{ inputs.slack_channel }}
           SLACK_BOT_TOKEN: ${{ secrets.slack_bot_token }}
@@ -338,6 +343,24 @@ jobs:
           set -euo pipefail
           if [ -z "$SLACK_BOT_TOKEN" ]; then
             echo "::warning::slack_channel is set but slack_bot_token secret is missing; skipping Slack notification."
+            exit 0
+          fi
+          # PR-lifetime dedupe: count bot-authored reviews whose body starts with the
+          # marker emitted by the approve arm of "Apply verdict". The review we just
+          # posted is included in the listing, so the first-ever would-have-approved
+          # run sees exactly 1; subsequent runs see >= 2 and skip Slack.
+          bot_user=$(gh api user --jq '.login')
+          prior_count=$(
+            gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
+              | jq --arg bot "$bot_user" '
+                  [.[] | select(.user.login == $bot
+                    and ((.body // "") | startswith("AI Review: Would have approved")))]
+                  | length
+              '
+          )
+          if [ "$prior_count" -gt 1 ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "Skipping Slack — AI has already would-have-approved this PR ($prior_count total)." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
           pr_url="${GITHUB_SERVER_URL}/${REPO}/pull/${PR_NUMBER}"
@@ -352,13 +375,13 @@ jobs:
             --arg reasoning "$reasoning" \
             '{
               channel: $channel,
-              text: ("AI auto-approved PR #" + $pr_num + " in " + $repo + ": " + $pr_title),
+              text: ("AI candidate for quick review: PR #" + $pr_num + " in " + $repo + ": " + $pr_title),
               blocks: ([
                 {
                   type: "section",
                   text: {
                     type: "mrkdwn",
-                    text: ("*AI auto-approved:* <" + $pr_url + "|#" + $pr_num + " — " + $pr_title + ">\n_Repo: `" + $repo + "`_")
+                    text: ("*AI would have approved* (candidate for quick review): <" + $pr_url + "|#" + $pr_num + " — " + $pr_title + ">\n_Repo: `" + $repo + "`_")
                   }
                 }
               ] + (if ($reasoning | length) > 0 then [{


### PR DESCRIPTION
## Summary
Follow-up to [DEVEX-1523](https://encodium.atlassian.net/browse/DEVEX-1523). The AI reviewer no longer submits formal GitHub approvals — human review is always required. When the AI would have approved, it now posts a `--comment` review explaining why, and Slack is pinged only the first time per PR so humans see a quick-review candidate without channel spam on every push.

## What changed
- **No more formal AI approvals.** The `approve` arm of the apply-verdict step now uses `gh pr review --comment`. The body opens with the stable marker `AI Review: Would have approved — human review still required.` followed by `I would have approved this PR for the following reasons:` and the AI's reasoning.
- **Output renamed** `did_approve` → `would_have_approved` to reflect the new semantics.
- **Slack dedupe per PR.** The Slack step now lists bot-authored reviews on the PR and skips if a prior review already begins with the marker, so re-pushes and re-runs don't re-ping. The first-ever would-have-approved run sees exactly one (the one we just posted) and notifies; subsequent runs see ≥2 and skip with a step-summary note.
- **Slack copy** updated from "AI auto-approved" to "AI would have approved (candidate for quick review)".
- **AI prompt** clarifies that `approve` now triggers a comment rather than a formal approval so calibration stays right.
- **Check Run** for the would-have-approved case keeps `success` (green) with title "AI would have approved" so the signal remains visible at a glance.

## Unchanged
- Size gate, dismiss-unauthorized-approvals defense-in-depth step, `comment` and `defer` arms, and Check Run publishing. Token permissions stay `pull-requests: write`.

## Blast radius
Reusable workflow consumed via `@main` by [encodium/radmin](https://github.com/encodium/radmin/blob/main/.github/workflows/claude-review.yaml) and [encodium/manage](https://github.com/encodium/manage/blob/main/.github/workflows/claude-review.yaml). Both pick up the change on the next PR event after merge. This PR's own CI still runs the pre-merge workflow, so the new behavior is only observable on the next PR in a consumer repo.

## Test plan
- [ ] Open a small low-risk PR in a consumer repo (radmin or manage) and confirm: AI posts a `--comment` review beginning with the marker line, no formal approval shows on the PR, `AI Code Review` check is green.
- [ ] Push a second commit to the same PR (or re-run the workflow) and confirm the marker review repeats but the Slack channel does NOT receive a second ping.
- [ ] Open a PR that the AI would `comment` on (real concerns) — confirm inline comments + neutral check, no Slack ping.
- [ ] Open a PR that the AI defers — confirm deferral comment + skipped check, no Slack ping.
- [ ] Confirm the dismiss-unauthorized-approvals step is unchanged and still arms (no behavior change expected).

Made with [Cursor](https://cursor.com)

[DEVEX-1523]: https://revolutionparts.atlassian.net/browse/DEVEX-1523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ