### PR TITLE
[PLAT-5001] Add platforms input to php-laravel-build-push workflow

### DIFF
--- a/.github/workflows/php-laravel-build-push.yaml
+++ b/.github/workflows/php-laravel-build-push.yaml
@@ -50,6 +50,11 @@ on:
       new_tag:
         type: string
         required: true
+      platforms:
+        description: "Comma-separated target platforms for docker buildx (e.g. linux/amd64,linux/arm64)."
+        required: false
+        type: string
+        default: "linux/amd64"
     secrets:
       packagist_username:
         required: true
@@ -121,7 +126,7 @@ jobs:
           push: true
           target: app
           file: ${{ inputs.dockerfile_app_path }}
-          platforms: linux/amd64
+          platforms: ${{ inputs.platforms }}
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.new_tag }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
@@ -149,7 +154,7 @@ jobs:
           context: .
           push: true
           file: ${{ inputs.dockerfile_webserver_path }}
-          platforms: linux/amd64
+          platforms: ${{ inputs.platforms }}
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.webserver_tag_prefix }}${{ inputs.new_tag }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.webserver_tag_prefix }}latest
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-webserver
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-webserver,mode=max
@@ -214,7 +219,7 @@ jobs:
           context: .
           push: true
           file: ${{ inputs.dockerfile_cli_path }}
-          platforms: linux/amd64
+          platforms: ${{ inputs.platforms }}
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cli-${{ inputs.new_tag }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cli-latest
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-cli
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-cli,mode=max


### PR DESCRIPTION
## Summary

- Adds a `platforms` workflow_call input to `php-laravel-build-push.yaml` for docker buildx multi-arch builds
- Defaults to `linux/amd64` so existing consumers (payments, shipping, marketplaces, etc.) keep current single-arch behavior without changes
- App, webserver, and CLI build jobs all use `${{ inputs.platforms }}` instead of hardcoded `linux/amd64`

## Motivation

Part of Graviton rollout phase 1. Listings needs to publish multi-arch CLI images on merge-main; this shared workflow change enables opt-in per repo via `platforms: linux/amd64,linux/arm64`.

## Related

- JIRA: https://revolutionparts.atlassian.net/browse/PLAT-5001
- Depends on: PLAT-4999 (local arm64 validation — done)
- Follow-up: listings PR will pass `platforms: linux/amd64,linux/arm64` explicitly (merge listings after this PR)

## Test plan

- [ ] Merge this PR first
- [ ] Verify an existing consumer (e.g. payments merge-main) still builds amd64-only with no workflow changes
- [ ] Merge listings PLAT-5001 PR and confirm `ghcr.io/encodium/listings:cli-<TAG>` manifest lists both amd64 and arm64


Made with [Cursor](https://cursor.com)