### PR TITLE
DEVEX-1650: add _compute-rt-tag composite action for Release Train v2

### DIFF
--- a/.github/actions/_compute-rt-tag/README.md
+++ b/.github/actions/_compute-rt-tag/README.md
@@ -1,0 +1,101 @@
+# `_compute-rt-tag` composite action
+
+Computes and emits the next Release Train v2 (RT v2) tag and matching prerelease for the current `rt-<N>` branch. Designed for the per-repo `Build.yaml` rt-* push trigger.
+
+Part of [DEVEX-1579](https://revolutionparts.atlassian.net/browse/DEVEX-1579).
+
+## Behaviour
+
+On push to `rt-<N>`, this action:
+
+1. Parses `<N>` from the branch name.
+2. Finds the rt-N **cut SHA** as `git merge-base origin/main HEAD`.
+3. Reads the **base version** `vX.Y.Z` from the tag at the cut SHA (relies on main tagging every push via mathieudutour).
+4. Counts existing `vX.Y.Z-rc.<N>.*` tags to compute the next `iter`.
+5. Pushes a lightweight tag `vX.Y.Z-rc.<N>.<iter>`.
+6. Creates a matching GitHub Release with `prerelease=true`.
+
+Tag and release are emitted **atomically as a pair** — the promote workflow can later flip `prerelease=false` knowing the GH Release always exists.
+
+## Tag format ⚠️
+
+The original DEVEX-1579 spec proposed `vX.Y.Z-rt.<N>.rc.<iter>`. **That format does not work** because composer's `VersionParser` rejects custom pre-release identifiers (only `rc`, `beta`, `alpha`, `dev`, `patch` are accepted).
+
+This action uses **`vX.Y.Z-rc.<N>.<iter>`** instead (e.g., `v4.7.0-rc.147.3`):
+- Composer accepts it as-is, even with `minimum-stability: stable`.
+- Standard semver sort order is correct (`rc.147.1 < rc.147.2 < rc.147.10 < rc.148.1 < (stable) X.Y.Z`).
+- Train number and iter are uniquely parseable via `rc\.(\d+)\.(\d+)`.
+- Distinguishable from legacy v1 `vX.Y.Z-rc.<iter>` (2-segment) by segment count.
+
+## Caller requirements
+
+- Branch matches `rt-<N>` (numeric N).
+- `actions/checkout` with `fetch-depth: 0` and `fetch-tags: true` (or no `fetch-tags: false`).
+- `Build.yaml` declares `concurrency: { group: 'rt-build-${{ github.ref }}', cancel-in-progress: false }` to prevent iter races. This action does **not** serialise on its own.
+- A token with `contents: write` is provided via the `github_token` input.
+
+## Inputs
+
+| Name | Required | Description |
+|---|---|---|
+| `github_token` | yes | Token with `contents: write` for tag push and `gh release create`. |
+
+## Outputs
+
+| Name | Example | Description |
+|---|---|---|
+| `tag` | `v4.7.0-rc.147.3` | Full emitted tag. |
+| `train_number` | `147` | Train N parsed from the branch name. |
+| `iter` | `3` | rc iteration number. |
+| `base_version` | `v4.7.0` | Frozen base version from cut SHA. |
+
+## Usage
+
+```yaml
+# In <app>/.github/workflows/Build.yaml
+
+on:
+  push:
+    branches:
+      - main
+      - 'rt-*'
+
+concurrency:
+  group: rt-build-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  rt-build:
+    if: startsWith(github.ref, 'refs/heads/rt-')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - id: rt_tag
+        uses: encodium/.github/.github/actions/_compute-rt-tag@main
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        run: |
+          docker build -t "ghcr.io/${{ github.repository }}:${{ steps.rt_tag.outputs.tag }}" .
+          docker push "ghcr.io/${{ github.repository }}:${{ steps.rt_tag.outputs.tag }}"
+```
+
+## Failure modes
+
+| Error | Cause | Fix |
+|---|---|---|
+| `Expected branch matching 'rt-<N>'` | Action invoked on a non-rt branch | Gate the rt-build job with `if: startsWith(github.ref, 'refs/heads/rt-')`. |
+| `Could not find merge-base` | Checkout didn't fetch full history | Set `fetch-depth: 0` on `actions/checkout`. |
+| `No vX.Y.Z tag at cut SHA` | Main isn't tagging every push, or the cut SHA's tag is missing | Verify Phase 1 (DEVEX-1651) foundation work landed — main path of Build.yaml must invoke mathieudutour. |
+| `Computed tag already exists` | Iter race — two rt-build runs computed the same iter concurrently | Confirm `concurrency:` group set on Build.yaml. |
+
+## Why a lightweight tag, not annotated?
+
+Matches the existing `encodium/common` semantic-release pattern (`git tag "$FINAL_TAG"`). The GH Release carries the metadata (title, notes); the tag itself is just a pointer.

--- a/.github/actions/_compute-rt-tag/action.yml
+++ b/.github/actions/_compute-rt-tag/action.yml
@@ -1,0 +1,114 @@
+name: 'Compute and emit RT tag'
+description: |
+  Computes the next vX.Y.Z-rc.<N>.<iter> tag for the current rt-N branch,
+  pushes the lightweight tag, and creates a matching GitHub prerelease.
+
+  Designed for Release Train v2 (DEVEX-1579). The caller must:
+    - Be running on a branch matching 'rt-<N>'.
+    - Have run actions/checkout with fetch-depth: 0 and fetch-tags: true so
+      git merge-base and tag enumeration can see full history.
+    - Hold the Build.yaml concurrency group 'rt-build-${{ github.ref }}' to
+      prevent iter races (this action does NOT serialise on its own).
+
+  Base version is derived from the vX.Y.Z tag at the cut SHA
+  (merge-base between origin/main and HEAD). That tag exists because main
+  is configured to tag every push (radmin model). No state ledger is read.
+
+  NOTE on the tag format: the original spec proposed vX.Y.Z-rt.<N>.rc.<iter>
+  but composer's VersionParser rejects custom pre-release identifiers like
+  'rt'. Only the standard set (rc, beta, alpha, dev, patch) is accepted, so
+  the scheme uses 'rc.<N>.<iter>' where <N> is the train number. This
+  remains uniquely parseable (3-segment pre-release distinguishes new v2
+  tags from legacy v1 'vX.Y.Z-rc.<iter>' 2-segment tags) and sorts
+  correctly via standard semver comparison.
+
+inputs:
+  github_token:
+    description: 'Token with contents:write to push the tag and create the GH release'
+    required: true
+
+outputs:
+  tag:
+    description: 'The emitted tag (e.g., v4.7.0-rc.147.3)'
+    value: ${{ steps.compute.outputs.tag }}
+  train_number:
+    description: 'The train N parsed from the rt-N branch name'
+    value: ${{ steps.compute.outputs.train_number }}
+  iter:
+    description: 'The rc iteration number'
+    value: ${{ steps.compute.outputs.iter }}
+  base_version:
+    description: 'The vX.Y.Z base version (frozen at rt-N cut time)'
+    value: ${{ steps.compute.outputs.base_version }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Compute tag components
+      id: compute
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        branch="${GITHUB_REF_NAME}"
+        if [[ ! "$branch" =~ ^rt-[0-9]+$ ]]; then
+          echo "::error::Expected branch matching 'rt-<N>', got '$branch'."
+          echo "::error::This action is only valid on rt-* branches."
+          exit 1
+        fi
+        train_n="${branch#rt-}"
+
+        cut_sha=$(git merge-base origin/main HEAD)
+        if [ -z "$cut_sha" ]; then
+          echo "::error::Could not find merge-base between origin/main and HEAD."
+          echo "::error::Ensure checkout used fetch-depth: 0."
+          exit 1
+        fi
+
+        base=$(git tag --points-at "$cut_sha" \
+          | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+          | head -1 \
+          || true)
+        if [ -z "$base" ]; then
+          echo "::error::No vX.Y.Z tag at cut SHA $cut_sha."
+          echo "::error::Main must tag every push (mathieudutour) for this to work."
+          echo "::error::Verify the Phase 1 foundation work has landed on main."
+          exit 1
+        fi
+
+        iter_count=$(git tag -l "${base}-rc.${train_n}.*" | wc -l | tr -d ' ')
+        iter=$((iter_count + 1))
+        tag="${base}-rc.${train_n}.${iter}"
+
+        if git rev-parse "refs/tags/${tag}" >/dev/null 2>&1; then
+          echo "::error::Computed tag ${tag} already exists."
+          echo "::error::Likely an iter race — confirm Build.yaml has the concurrency group set."
+          exit 1
+        fi
+
+        {
+          echo "train_number=$train_n"
+          echo "base_version=$base"
+          echo "iter=$iter"
+          echo "tag=$tag"
+        } >> "$GITHUB_OUTPUT"
+
+        echo "Computed tag: $tag (base=$base, train=$train_n, iter=$iter, cut_sha=$cut_sha)"
+
+    - name: Push tag
+      shell: bash
+      run: |
+        set -euo pipefail
+        git tag "${{ steps.compute.outputs.tag }}"
+        git push origin "${{ steps.compute.outputs.tag }}"
+
+    - name: Create GitHub prerelease
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+      run: |
+        set -euo pipefail
+        gh release create "${{ steps.compute.outputs.tag }}" \
+          --prerelease \
+          --title "${{ steps.compute.outputs.tag }}" \
+          --notes "Release Train ${{ steps.compute.outputs.train_number }}, rc.${{ steps.compute.outputs.iter }} (base ${{ steps.compute.outputs.base_version }})"


### PR DESCRIPTION
## Summary

Adds `_compute-rt-tag` composite action — the foundational piece for Release Train v2 ([DEVEX-1579](https://revolutionparts.atlassian.net/browse/DEVEX-1579)) per-repo Build.yaml rt-* path. Tracked by [DEVEX-1650](https://revolutionparts.atlassian.net/browse/DEVEX-1650) (Phase 0 spike).

## Behaviour

On push to `rt-<N>`, callers of this action get:
- Next rt-N tag computed from git context (no state ledger).
- Lightweight tag pushed + matching GH Release created with `prerelease=true` — atomically as a pair.

Base version comes from `git tag --points-at $(git merge-base origin/main HEAD)`. Iter is the count of existing `${base}-rc.${N}.*` tags + 1.

## ⚠️ Tag format change from DEVEX-1579 spec

Spike found that composer's `VersionParser` rejects the originally-proposed `vX.Y.Z-rt.<N>.rc.<iter>` format. Only standard pre-release identifiers (`rc`, `beta`, `alpha`, `dev`, `patch`) are accepted.

**New format**: `vX.Y.Z-rc.<N>.<iter>` (e.g., `v4.7.0-rc.147.3`).

- Composer-accepted with `minimum-stability: stable`.
- Sorts correctly via standard semver comparison.
- Train + iter extractable via `rc\.(\d+)\.(\d+)`.
- 3-segment shape distinguishes new v2 tags from legacy 2-segment v1 `vX.Y.Z-rc.<iter>` tags.

Confirmed with the assignee; spec amendment will follow on the parent ticket.

## Tests run locally

- Synthetic git state with `v4.6.0`, `v4.7.0` on main, `rt-147` with `rc.147.1`, `rc.147.2` already → action emits `v4.7.0-rc.147.3`. ✅
- Main moves forward to `v4.7.1` after rt-147 cut → base STILL `v4.7.0` (frozen at cut SHA). ✅
- Missing base tag at cut SHA → action fails with clear error. ✅
- Pre-release tag (e.g. `v4.7.0-alpha.1`) at cut SHA → regex correctly rejects; treated as missing base. ✅
- Legacy 2-segment tags don't pollute iter count (glob `rc.147.*` doesn't match `rc.7`). ✅

## Caller requirements

Documented in the action's README. Key points:
- `actions/checkout` with `fetch-depth: 0` and `fetch-tags: true`.
- `Build.yaml` declares `concurrency: { group: 'rt-build-${{ github.ref }}', cancel-in-progress: false }` to prevent iter races.
- Token with `contents: write`.

## Not in this PR

- No app-side wiring yet (Phase 1 / Phase 2 / Phase 3 work).
- No common-side `rt-build.yaml` yet (Phase 1).
- No `start-release-train.yaml` or `pin-common-on-rt.yaml` yet (Phase 1).

Reviewing the action's logic + tag format change is the ask.


[DEVEX-1579]: https://revolutionparts.atlassian.net/browse/DEVEX-1579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DEVEX-1650]: https://revolutionparts.atlassian.net/browse/DEVEX-1650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ