### PR TITLE
[PLAT-5019] Split multi-arch php-laravel builds across native runners

### DIFF
--- a/.github/workflows/php-laravel-build-push.yaml
+++ b/.github/workflows/php-laravel-build-push.yaml
@@ -63,10 +63,14 @@ on:
       gh_token:
         required: true
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build-and-push-app-image:
-    if: ${{ inputs.build_app_image }}
-    runs-on: ubuntu-latest
+    if: ${{ inputs.build_app_image && !(contains(inputs.platforms, 'arm64') && contains(inputs.platforms, 'amd64')) }}
+    runs-on: ${{ contains(inputs.platforms, 'arm64') && !contains(inputs.platforms, 'amd64') && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     name: Build + Push Application Image
     steps:
       - name: Checkout
@@ -130,9 +134,110 @@ jobs:
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.new_tag }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
-  build-and-push-webserver-image:
-    if: ${{ inputs.build_webserver_image }}
+  build-and-push-app-image-arch:
+    if: ${{ inputs.build_app_image && contains(inputs.platforms, 'arm64') && contains(inputs.platforms, 'amd64') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            suffix: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            suffix: arm64
+    runs-on: ${{ matrix.runner }}
+    name: Build + Push Application Image (${{ matrix.suffix }})
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ inputs.php_version }}
+          tools: composer
+          coverage: none
+          extensions: ${{ inputs.php_extensions }}
+        env:
+          COMPOSER_AUTH_JSON: |
+            {
+              "http-basic": {
+                "repo.packagist.com": {
+                  "username": "${{ secrets.packagist_username }}",
+                  "password": "${{ secrets.packagist_password }}"
+                }
+              }
+            }
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - name: Cache dependencies
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-${{ matrix.suffix }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.suffix }}-composer-
+      - name: Install dependencies
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer install --no-dev --prefer-dist --no-interaction --no-progress --optimize-autoloader
+      - name: Run Artisan Cache Commands
+        run: |
+          php artisan config:cache --no-interaction
+          php artisan route:cache --no-interaction
+          test -d ./resources/views && php artisan view:cache --no-interaction || true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.gh_token }}
+      - name: Docker Build and Push
+        uses: docker/build-push-action@v5
+        env:
+          REGISTRY: ghcr.io
+          IMAGE_NAME: ${{ github.repository }}
+        with:
+          context: .
+          push: true
+          target: app
+          file: ${{ inputs.dockerfile_app_path }}
+          platforms: ${{ matrix.platform }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.new_tag }}-${{ matrix.suffix }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-${{ matrix.suffix }}
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-${{ matrix.suffix }},mode=max
+  merge-app-image-manifest:
+    if: ${{ inputs.build_app_image && contains(inputs.platforms, 'arm64') && contains(inputs.platforms, 'amd64') }}
+    needs: [build-and-push-app-image-arch]
     runs-on: ubuntu-latest
+    name: Merge Application Image Manifest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.gh_token }}
+      - name: Merge multi-arch application manifest
+        env:
+          REGISTRY: ghcr.io
+          IMAGE_NAME: ${{ github.repository }}
+          NEW_TAG: ${{ inputs.new_tag }}
+        run: |
+          docker buildx imagetools create \
+            -t "${REGISTRY}/${IMAGE_NAME}:${NEW_TAG}" \
+            -t "${REGISTRY}/${IMAGE_NAME}:latest" \
+            "${REGISTRY}/${IMAGE_NAME}:${NEW_TAG}-amd64" \
+            "${REGISTRY}/${IMAGE_NAME}:${NEW_TAG}-arm64"
+  build-and-push-webserver-image:
+    if: ${{ inputs.build_webserver_image && !(contains(inputs.platforms, 'arm64') && contains(inputs.platforms, 'amd64')) }}
+    runs-on: ${{ contains(inputs.platforms, 'arm64') && !contains(inputs.platforms, 'amd64') && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     name: Build + Push Webserver (e.g. nginx) Image
     steps:
       - name: Checkout
@@ -158,9 +263,73 @@ jobs:
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.webserver_tag_prefix }}${{ inputs.new_tag }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.webserver_tag_prefix }}latest
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-webserver
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-webserver,mode=max
-  build-and-push-cli-image:
-    if: ${{ inputs.build_cli_image }}
+  build-and-push-webserver-image-arch:
+    if: ${{ inputs.build_webserver_image && contains(inputs.platforms, 'arm64') && contains(inputs.platforms, 'amd64') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            suffix: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            suffix: arm64
+    runs-on: ${{ matrix.runner }}
+    name: Build + Push Webserver Image (${{ matrix.suffix }})
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.gh_token }}
+      - name: Docker Build and Push
+        uses: docker/build-push-action@v5
+        env:
+          REGISTRY: ghcr.io
+          IMAGE_NAME: ${{ github.repository }}
+        with:
+          context: .
+          push: true
+          file: ${{ inputs.dockerfile_webserver_path }}
+          platforms: ${{ matrix.platform }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.webserver_tag_prefix }}${{ inputs.new_tag }}-${{ matrix.suffix }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-webserver-${{ matrix.suffix }}
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-webserver-${{ matrix.suffix }},mode=max
+  merge-webserver-image-manifest:
+    if: ${{ inputs.build_webserver_image && contains(inputs.platforms, 'arm64') && contains(inputs.platforms, 'amd64') }}
+    needs: [build-and-push-webserver-image-arch]
     runs-on: ubuntu-latest
+    name: Merge Webserver Image Manifest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.gh_token }}
+      - name: Merge multi-arch webserver manifest
+        env:
+          REGISTRY: ghcr.io
+          IMAGE_NAME: ${{ github.repository }}
+          NEW_TAG: ${{ inputs.new_tag }}
+          TAG_PREFIX: ${{ inputs.webserver_tag_prefix }}
+        run: |
+          docker buildx imagetools create \
+            -t "${REGISTRY}/${IMAGE_NAME}:${TAG_PREFIX}${NEW_TAG}" \
+            -t "${REGISTRY}/${IMAGE_NAME}:${TAG_PREFIX}latest" \
+            "${REGISTRY}/${IMAGE_NAME}:${TAG_PREFIX}${NEW_TAG}-amd64" \
+            "${REGISTRY}/${IMAGE_NAME}:${TAG_PREFIX}${NEW_TAG}-arm64"
+  build-and-push-cli-image:
+    if: ${{ inputs.build_cli_image && !(contains(inputs.platforms, 'arm64') && contains(inputs.platforms, 'amd64')) }}
+    runs-on: ${{ contains(inputs.platforms, 'arm64') && !contains(inputs.platforms, 'amd64') && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     name: Build + Push CLI Image
     steps:
       - name: Checkout
@@ -223,3 +392,103 @@ jobs:
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cli-${{ inputs.new_tag }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cli-latest
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-cli
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-cli,mode=max
+  build-and-push-cli-image-arch:
+    if: ${{ inputs.build_cli_image && contains(inputs.platforms, 'arm64') && contains(inputs.platforms, 'amd64') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            suffix: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            suffix: arm64
+    runs-on: ${{ matrix.runner }}
+    name: Build + Push CLI Image (${{ matrix.suffix }})
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ inputs.php_version }}
+          tools: composer
+          coverage: none
+          extensions: ${{ inputs.php_extensions }}
+        env:
+          COMPOSER_AUTH_JSON: |
+            {
+              "http-basic": {
+                "repo.packagist.com": {
+                  "username": "${{ secrets.packagist_username }}",
+                  "password": "${{ secrets.packagist_password }}"
+                }
+              }
+            }
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - name: Cache dependencies
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-${{ matrix.suffix }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.suffix }}-composer-
+      - name: Install dependencies
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer install --no-dev --prefer-dist --no-interaction --no-progress --optimize-autoloader
+      - name: Run Artisan Cache Commands
+        run: |
+          php artisan config:cache --no-interaction
+          php artisan route:cache --no-interaction
+          test -d ./resources/views && php artisan view:cache --no-interaction || true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.gh_token }}
+      - name: Docker Build and Push
+        uses: docker/build-push-action@v5
+        env:
+          REGISTRY: ghcr.io
+          IMAGE_NAME: ${{ github.repository }}
+        with:
+          context: .
+          push: true
+          file: ${{ inputs.dockerfile_cli_path }}
+          platforms: ${{ matrix.platform }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cli-${{ inputs.new_tag }}-${{ matrix.suffix }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-cli-${{ matrix.suffix }}
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-cli-${{ matrix.suffix }},mode=max
+  merge-cli-image-manifest:
+    if: ${{ inputs.build_cli_image && contains(inputs.platforms, 'arm64') && contains(inputs.platforms, 'amd64') }}
+    needs: [build-and-push-cli-image-arch]
+    runs-on: ubuntu-latest
+    name: Merge CLI Image Manifest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.gh_token }}
+      - name: Merge multi-arch CLI manifest
+        env:
+          REGISTRY: ghcr.io
+          IMAGE_NAME: ${{ github.repository }}
+          NEW_TAG: ${{ inputs.new_tag }}
+        run: |
+          docker buildx imagetools create \
+            -t "${REGISTRY}/${IMAGE_NAME}:cli-${NEW_TAG}" \
+            -t "${REGISTRY}/${IMAGE_NAME}:cli-latest" \
+            "${REGISTRY}/${IMAGE_NAME}:cli-${NEW_TAG}-amd64" \
+            "${REGISTRY}/${IMAGE_NAME}:cli-${NEW_TAG}-arm64"


### PR DESCRIPTION
## Jira

https://revolutionparts.atlassian.net/browse/PLAT-5019

## Summary

- When `platforms` includes both `linux/amd64` and `linux/arm64`, build each architecture on a native GitHub Actions runner in parallel instead of QEMU on a single amd64 runner
- Push per-arch tags (e.g. `cli-v0.24.0-amd64`, `cli-v0.24.0-arm64`) with per-arch registry cache keys (`buildcache-cli-amd64`, `buildcache-cli-arm64`)
- Merge into final multi-arch tags via `docker buildx imagetools create` (`cli-TAG`, `cli-latest`, etc.)
- Single-platform builds (`linux/amd64` default) unchanged

## Motivation

Listings merge-main multi-arch CLI builds took ~62 minutes because arm64 PHP extension compilation ran under QEMU on `ubuntu-latest`. Native arm64 runners should cut that to roughly the slowest single-arch build.

## Pipeline (after this change)

Example: **Listings merge-main** (CLI-only multi-arch).

```mermaid
flowchart TB
  subgraph listings["listings — Merge Main Workflow"]
    tag["Calculate Build Tag<br/>ubuntu-latest · ~9s"]
    tag --> build["build-and-push-images<br/>calls encodium/.github<br/>php-laravel-build-push.yaml"]
    build --> prerelease["Prerelease + GH release"]
    build --> deploy["Deploy to staging EKS"]
  end

  subgraph shared["encodium/.github — php-laravel-build-push.yaml"]
    direction TB

    subgraph cli_amd64["Build + Push CLI Image (amd64)"]
      direction TB
      a1["ubuntu-latest"]
      a2["composer install + artisan cache"]
      a3["docker buildx push<br/>platform: linux/amd64"]
      a4["tag: cli-vX.Y.Z-amd64<br/>cache: buildcache-cli-amd64"]
      a1 --> a2 --> a3 --> a4
    end

    subgraph cli_arm64["Build + Push CLI Image (arm64)"]
      direction TB
      b1["ubuntu-24.04-arm<br/>native Graviton runner"]
      b2["composer install + artisan cache"]
      b3["docker buildx push<br/>platform: linux/arm64"]
      b4["tag: cli-vX.Y.Z-arm64<br/>cache: buildcache-cli-arm64"]
      b1 --> b2 --> b3 --> b4
    end

    merge["Merge CLI Image Manifest<br/>ubuntu-latest"]
    merge_step["docker buildx imagetools create<br/>→ cli-vX.Y.Z + cli-latest<br/>multi-arch manifest"]

    build --> cli_amd64
    build --> cli_arm64
    cli_amd64 --> merge
    cli_arm64 --> merge
    merge --> merge_step
  end

  merge_step --> ghcr["GHCR<br/>ghcr.io/encodium/listings:cli-TAG"]
```

### Before vs after (CLI image build)

```mermaid
flowchart LR
  subgraph before["Before PLAT-5019"]
    direction TB
    old["ubuntu-latest only"]
    qemu["Single buildx job<br/>platforms: amd64 + arm64"]
    qemu_arm["arm64 layers via QEMU<br/>~59 min PHP ext compile"]
    old --> qemu --> qemu_arm
  end

  subgraph after["After PLAT-5019"]
    direction TB
    par["Parallel native builds"]
    amd["amd64 · ubuntu-latest · ~36s"]
    arm["arm64 · ubuntu-24.04-arm · native"]
    m["imagetools merge · ~30s"]
    par --> amd
    par --> arm
    amd --> m
    arm --> m
  end
```

When all three image types are enabled (app + webserver + CLI), each image type follows the same pattern: **2 parallel arch jobs** + **1 merge job** → final tags (`TAG`/`latest`, `webserver-TAG`/`webserver-latest`, `cli-TAG`/`cli-latest`). Those three families still run in parallel with each other.

## Test plan

- [ ] Merge this PR
- [ ] Trigger Listings merge-main (or wait for next main push) and confirm:
  - Parallel amd64 + arm64 CLI build jobs on correct runners
  - Final `cli-TAG` manifest lists both architectures
  - Total image build time < 15 min with warm per-arch cache