### PR TITLE
feat(ci): add golangci_lint_version input to go-test workflow

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -1,6 +1,12 @@
 name: Go Test
 on:
   workflow_call:
+    inputs:
+      golangci_lint_version:
+        description: golangci-lint version passed to golangci-lint-action
+        required: false
+        type: string
+        default: v2.11.4
     secrets:
       token:
         required: true
@@ -40,7 +46,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.11.4
+          version: ${{ inputs.golangci_lint_version }}
           args: --output.text.print-issued-lines -c ./.golangci.yml --max-same-issues 0 -v --timeout 5m
       - name: Go Generate
         run: go generate ./... && git diff --exit-code


### PR DESCRIPTION
## Summary
- Adds optional `golangci_lint_version` input to the shared `go-test` reusable workflow
- Default remains `v2.11.4` so existing Go repos are unchanged
- Enables per-repo opt-in to newer golangci-lint (needed for PLAT-4889 / products-api)

## Test plan
- [ ] Merge and verify products-api PR CI passes with `golangci_lint_version: v2.12.2`
- [ ] Verify other Go repos still use default v2.11.4

JIRA: https://revolutionparts.atlassian.net/browse/PLAT-4889

Made with [Cursor](https://cursor.com)