### PR TITLE
DEVEX-1654: parse rt tag format in deploy notifications (Slack + Jellyfish)

### DIFF
--- a/.github/workflows/jellyfish-deploy-notification.yaml
+++ b/.github/workflows/jellyfish-deploy-notification.yaml
@@ -16,8 +16,35 @@ jobs:
   notify-jellyfish:
     runs-on: ubuntu-latest
     steps:
+      - name: Parse rt tag (if applicable)
+        id: parse
+        env:
+          IMAGE_TAG: ${{ inputs.image_tag }}
+        run: |
+          # Extract train_date + iter for RT v2 tags so the Jellyfish event
+          # carries enough information for the captain-handbook dashboard to
+          # plot iter@promotion per train. v1 legacy and plain semver also
+          # supported.
+          if [[ "$IMAGE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc\.([0-9]{4}-[0-9]{2}-[0-9]{2})\.([0-9]+)$ ]]; then
+            TRAIN="${BASH_REMATCH[1]}"
+            ITER="${BASH_REMATCH[2]}"
+            echo "format=v2"                            >> "$GITHUB_OUTPUT"
+            echo "train_date=$TRAIN"                    >> "$GITHUB_OUTPUT"
+            echo "iter=$ITER"                           >> "$GITHUB_OUTPUT"
+            echo "name_suffix= (train $TRAIN · rc.$ITER)" >> "$GITHUB_OUTPUT"
+          elif [[ "$IMAGE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc\.([0-9]+)$ ]]; then
+            ITER="${BASH_REMATCH[1]}"
+            echo "format=v1"                            >> "$GITHUB_OUTPUT"
+            echo "iter=$ITER"                           >> "$GITHUB_OUTPUT"
+            echo "name_suffix= (rc.$ITER legacy)"       >> "$GITHUB_OUTPUT"
+          else
+            echo "format=plain"                         >> "$GITHUB_OUTPUT"
+            echo "name_suffix="                         >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Dynamically set timestamp var
         run: echo TIMESTAMP_NOW=$(date --iso-8601=seconds) >> $GITHUB_ENV
+
       - name: Notify Jellyfish of deployment
         run: |
           curl -i -X POST \
@@ -25,7 +52,7 @@ jobs:
             -H 'X-jf-api-token: ${{ secrets.jellyfish_api_token }}' \
             -d '{
               "reference_id": "${{ github.event.repository.name }}-${{ inputs.image_tag }}-${{ github.run_id }}",
-              "name": "${{ github.event.repository.name }} deployment of ${{ inputs.image_tag }} to ${{ inputs.environment }} complete",
+              "name": "${{ github.event.repository.name }} deployment of ${{ inputs.image_tag }}${{ steps.parse.outputs.name_suffix }} to ${{ inputs.environment }} complete",
               "deployed_at": "${{ env.TIMESTAMP_NOW }}",
               "repo_name": "${{ github.repository }}",
               "commit_shas": ["${{ github.sha }}"],

--- a/.github/workflows/slack-deploy-notification.yaml
+++ b/.github/workflows/slack-deploy-notification.yaml
@@ -28,6 +28,38 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
+      - name: Parse rt tag (if applicable)
+        id: parse
+        env:
+          IMAGE_TAG: ${{ inputs.image_tag }}
+        run: |
+          # Surface train identifier + iter for RT-style tags so captains
+          # see "rc.3 of train 2026-06-18" in #releases, not just the full
+          # tag string. Two formats supported:
+          #   v2 (RT v2): vX.Y.Z-rc.<YYYY-MM-DD>.<iter>
+          #   v1 legacy:  vX.Y.Z-rc.<iter>
+          # Anything else (clean semver, custom suffix) gets a neutral
+          # summary so the notification still goes out.
+          if [[ "$IMAGE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc\.([0-9]{4}-[0-9]{2}-[0-9]{2})\.([0-9]+)$ ]]; then
+            TRAIN="${BASH_REMATCH[1]}"
+            ITER="${BASH_REMATCH[2]}"
+            echo "format=v2"                                       >> "$GITHUB_OUTPUT"
+            echo "train_date=$TRAIN"                               >> "$GITHUB_OUTPUT"
+            echo "iter=$ITER"                                      >> "$GITHUB_OUTPUT"
+            echo "summary=train $TRAIN · rc.$ITER"                 >> "$GITHUB_OUTPUT"
+          elif [[ "$IMAGE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc\.([0-9]+)$ ]]; then
+            ITER="${BASH_REMATCH[1]}"
+            echo "format=v1"                                       >> "$GITHUB_OUTPUT"
+            echo "iter=$ITER"                                      >> "$GITHUB_OUTPUT"
+            echo "summary=rc.$ITER (legacy v1)"                    >> "$GITHUB_OUTPUT"
+          elif [[ "$IMAGE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "format=plain"                                    >> "$GITHUB_OUTPUT"
+            echo "summary=clean release"                           >> "$GITHUB_OUTPUT"
+          else
+            echo "format=unknown"                                  >> "$GITHUB_OUTPUT"
+            echo "summary=${IMAGE_TAG}"                            >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Send deployment notification
         uses: slackapi/slack-github-action@v1.24.0
         env:
@@ -36,13 +68,13 @@ jobs:
         with:
           payload: |
             {
-              "text": "${{ github.event.repository.name }} deployed",
+              "text": "${{ github.event.repository.name }} deployed — ${{ steps.parse.outputs.summary }}",
               "blocks": [
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*${{ github.event.repository.name }} deployed by ${{ github.triggering_actor }}*\n\tView the <${{ inputs.dashboard_url }}|Deployment>\n\tView the <${{ inputs.apm_url }}|Service APM>"
+                    "text": "*${{ github.event.repository.name }} deployed* — _${{ steps.parse.outputs.summary }}_\nby ${{ github.triggering_actor }}\n\tView the <${{ inputs.dashboard_url }}|Deployment>\n\tView the <${{ inputs.apm_url }}|Service APM>"
                   },
                   "accessory": {
                     "type": "button",


### PR DESCRIPTION
Phase 4 of Release Train v2 ([DEVEX-1579](https://revolutionparts.atlassian.net/browse/DEVEX-1579) / [DEVEX-1654](https://revolutionparts.atlassian.net/browse/DEVEX-1654)). Self-contained.

## What changes

Both `slack-deploy-notification.yaml` and `jellyfish-deploy-notification.yaml` gain a parse step that classifies `image_tag` into v2 / v1 / plain / unknown:

| Tag | Format | Slack summary |
|---|---|---|
| `v4.7.0-rc.2026-06-18.3` | v2 (RT v2) | _train 2026-06-18 · rc.3_ |
| `v4.7.0-rc.7` | v1 legacy | _rc.7 (legacy v1)_ |
| `v4.7.0` | plain | _clean release_ |
| anything else | unknown | _(the tag, passthrough)_ |

Slack message now reads `listings-url-service deployed — train 2026-06-18 · rc.3` instead of just the bare tag. Captains see the train + iter at a glance in #releases.

Jellyfish event `name` field gets the same parenthetical suffix; `reference_id` is unchanged so existing dashboards don't break.

## Why now

Dual-format parsing is a stated DEVEX-1654 deliverable. Landing it before any v2 train cuts means the first real RT v2 promote will already surface 'rc.X of train YYYY-MM-DD' in #releases. Without this PR the Slack notification would just show the bare `v4.7.0-rc.2026-06-18.3` string, which is functional but not glanceable.

## Risk

Low. Both workflows are reusable (`workflow_call`). Existing callers don't change shape. If the parse step's regex misses an edge case, it falls into the `unknown` branch and the notification still fires with the raw tag — no regression vs. today.

## Not in this PR

- The captain-handbook dashboard that plots iter@promotion per train (Phase 5 / DEVEX-1655).
- Removal of the v1 (legacy) format support post-Phase 6 — kept here so the dual window is supported.

[DEVEX-1579]: https://revolutionparts.atlassian.net/browse/DEVEX-1579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DEVEX-1654]: https://revolutionparts.atlassian.net/browse/DEVEX-1654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ