### PR TITLE
DEVEX-1653: add rt_mode to build-php-v1 orchestrator

### DIFF
--- a/.github/workflows/build-php-v1.yaml
+++ b/.github/workflows/build-php-v1.yaml
@@ -18,6 +18,16 @@ on:
         required: false
         type: string
         default: "gha"
+      rt_mode:
+        description: |
+          Release-train mode. When true, skips mathieudutour and the trailing
+          GH Release step; the encodium/actions _compute-rt-tag composite
+          pushes the rt rc tag and creates the GH pre-release atomically up
+          front, and `build` uses that tag. Caller must trigger on rt-* refs
+          and grant `contents: write` to this job (see DEVEX-1653).
+        required: false
+        type: boolean
+        default: false
     secrets:
       packagist_username:
         required: true
@@ -27,12 +37,17 @@ on:
         required: true
     outputs:
       tag:
-        description: "The released tag"
-        value: ${{ jobs.tag-and-release.outputs.tag }}
+        description: "The released tag (either the main vX.Y.Z tag or the rt rc tag)."
+        value: ${{ jobs.tag-and-release.outputs.tag || jobs.compute-rt-tag.outputs.tag }}
 
 jobs:
+  # ─── non-rt path ────────────────────────────────────────────────────────
+  # Dry-run mathieudutour to compute what tag-and-release will emit; build
+  # uses that pre-computed value so the image tag and the eventual git tag
+  # agree. Skipped under rt_mode (the composite handles tagging atomically).
   calculate-tag:
     name: Calculate Build Tag
+    if: ${{ !inputs.rt_mode }}
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.dry_tag_version.outputs.new_tag }}
@@ -48,9 +63,40 @@ jobs:
           fetch_all_tags: true
           dry_run: true
 
+  # ─── rt-mode path ───────────────────────────────────────────────────────
+  # Single source of truth for rt rc tagging: the composite parses the
+  # rt-<YYYY-MM-DD> branch, computes the next iter, pushes the lightweight
+  # tag, and creates the GH pre-release. Build then consumes its output.
+  compute-rt-tag:
+    name: Compute RT Tag
+    if: ${{ inputs.rt_mode }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      tag: ${{ steps.rt_tag.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - id: rt_tag
+        uses: encodium/actions/.github/actions/_compute-rt-tag@main
+        with:
+          github_token: ${{ secrets.gh_token }}
+
   build:
     name: Build ${{ matrix.image.tag_prefix }}image
-    needs: [calculate-tag]
+    # Either calculate-tag (non-rt) or compute-rt-tag (rt) will run; the
+    # other is skipped by its branch gate. `always()` keeps build alive
+    # despite the skipped need, and the explicit success check prevents a
+    # false start if the active tag job actually failed.
+    needs: [calculate-tag, compute-rt-tag]
+    if: |
+      always() && (
+        needs.calculate-tag.result == 'success' ||
+        needs.compute-rt-tag.result == 'success'
+      )
     strategy:
       matrix:
         image: ${{ fromJSON(inputs.images) }}
@@ -60,7 +106,9 @@ jobs:
       image_name: ${{ matrix.image.image_name }}
       dockerfile: ${{ matrix.image.dockerfile }}
       build_target: ${{ matrix.image.target }}
-      tag: ${{ matrix.image.tag_prefix }}${{ needs.calculate-tag.outputs.tag }}
+      # Skipped jobs return empty-string outputs, so `||` picks the active
+      # path's tag without further gating.
+      tag: ${{ matrix.image.tag_prefix }}${{ needs.calculate-tag.outputs.tag || needs.compute-rt-tag.outputs.tag }}
       extra_tag: ${{ matrix.image.extra_tag }}
       cache_type: ${{ inputs.cache_type }}
     secrets:
@@ -68,8 +116,13 @@ jobs:
       packagist_password: ${{ secrets.packagist_password }}
       gh_token: ${{ secrets.gh_token }}
 
+  # ─── non-rt path (tail) ────────────────────────────────────────────────
+  # Re-runs mathieudutour (this time not dry) to actually push the tag,
+  # then creates the GH pre-release. Skipped under rt_mode — the composite
+  # already did both up front.
   tag-and-release:
     name: Github Tag and Release
+    if: ${{ !inputs.rt_mode }}
     needs: [build]
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
## Description

Adds an `rt_mode: boolean` input to the shared `build-php-v1` orchestrator. When `true` (caller triggers on `rt-*` refs), the orchestrator routes through `encodium/actions`' `_compute-rt-tag` composite to push the rt rc tag and create the GH pre-release atomically up front; `build` then consumes that tag. When `false` (default) behavior is identical to today.

**Related PRs:**
- https://github.com/encodium/listings-url-service/pull/89 (pilot — inline rt-build today; will migrate to this orchestrator in Phase 3)
- https://github.com/encodium/license_api/pull/99 (draft — to be revised to use this extended orchestrator instead of the hybrid pattern)

**Jira Issue:** https://revolutionparts.atlassian.net/browse/DEVEX-1653

## Background

Release Train v2 (DEVEX-1579) ships images tagged `vX.Y.Z-rc.<YYYY-MM-DD>.<iter>` from per-train `rt-<YYYY-MM-DD>` branches. The pilot (listings-url-service#89) proved the inline pattern works, but copying ~80 lines of rt-build logic into every consuming app's `Build.yaml` would mean 4 near-identical inline jobs to maintain (internal_api, rp_api, listings-url-service, license_api).

By teaching `build-php-v1` about rt mode, Phase 3 per-repo PRs become a few lines: a second `rt-build` job that calls the orchestrator with `rt_mode: true` and a different `images` JSON (no `extra_tag: latest` for rt builds). Tag-emission logic and GH Release creation stay in one place — the composite action.

The non-rt path is preserved verbatim. The two paths are mutually exclusive at job level (`if: ${{ !inputs.rt_mode }}` vs `if: ${{ inputs.rt_mode }}`); `build` waits on both with `always() && (success of either)` and selects the active tag via `||`.

**Scope of this PR (and what's deferred):**
- ✅ `build-php-v1.yaml`: extended.
- ⏭️ `build-php-laravel.yaml`: intentionally not extended here. The Laravel worker hardcodes `:latest` / `:webserver-latest` / `:cli-latest` across 6 build jobs — safely supporting rt mode there requires an `omit_latest_tag` input plumbed through the worker. That's a separate, larger PR. Among Phase 3 apps only `returns-api` consumes the Laravel orchestrator; it can use an inline rt-build path (matching the pilot) in the interim.
- ⏭️ `accounts-api` calls `php-laravel-build-push.yaml` directly (not the Laravel orchestrator) and `catalog_api` is fully inline — both will use inline rt-build paths in Phase 3.

## Caller responsibilities

For an rt-build job calling this orchestrator with `rt_mode: true`:
- Gate on `if: startsWith(github.ref, 'refs/heads/rt-')`
- `permissions: { contents: write }` on the calling job (propagates into `compute-rt-tag`)
- Pass a token with `contents:write` via `secrets.gh_token` (the pilot uses `REPO_WRITE_PAT`)
- Use a separate `images` JSON without `extra_tag: latest` — rt builds shouldn't move `:latest`

## Testing Information

- **YAML syntax:** lint-clean.
- **Behavioral diff on non-rt path:** zero. `calculate-tag` → `build` → `tag-and-release` chain runs identically; the only addition (`compute-rt-tag`) is gated on `rt_mode == true` and stays skipped.
- **End-to-end rt path:** validated in the sandbox `rt-99` train against the foundational composite action prior to this PR. This PR is a packaging refactor — same composite, same emitted tag, called from one place instead of inlined per-repo.
- **No-op on existing consumers:** internal_api, rp_api, returns-api, license_api, listings-url-service all call this workflow without specifying `rt_mode`; the default (`false`) preserves their current behavior.

Phase 3 follow-up PRs (one per consuming repo) will exercise rt_mode end-to-end before any per-repo merge.
