### PR TITLE
DEVEX-1398: shared notify-ci-failure workflow (workflow_run notifier)

### DIFF
--- a/.github/workflows/notify-ci-failure.yaml
+++ b/.github/workflows/notify-ci-failure.yaml
@@ -1,0 +1,42 @@
+name: Notify CI Failure
+on:
+  workflow_call:
+    inputs:
+      workflow:
+        description: "Name of the workflow that failed"
+        required: true
+        type: string
+      run_url:
+        description: "URL of the failed run"
+        required: true
+        type: string
+      head_sha:
+        description: "Commit SHA the failed run was for"
+        required: true
+        type: string
+      branch:
+        required: false
+        type: string
+        default: ""
+      actor:
+        required: false
+        type: string
+        default: ""
+    secrets:
+      slack_webhook_url:
+        required: true
+
+jobs:
+  notify:
+    name: Notify Slack
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post failure to Slack
+        uses: slackapi/slack-github-action@v2
+        with:
+          webhook: ${{ secrets.slack_webhook_url }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": ":rotating_light: *${{ github.repository }}* — *${{ inputs.workflow }}* failed on `${{ inputs.branch }}`\n*By:* ${{ inputs.actor }} · *Commit:* <${{ github.server_url }}/${{ github.repository }}/commit/${{ inputs.head_sha }}|${{ inputs.head_sha }}>\n<${{ inputs.run_url }}|View failed run>"
+            }


### PR DESCRIPTION
## Summary

Adds a shared reusable workflow `notify-ci-failure.yaml` that posts a Slack alert (via the org `SLACK_WEBHOOK_URL`) describing **which workflow failed** on `main`, with commit + run links.

It's input-driven so each repo can call it from a lightweight `workflow_run` watcher (`ci-failure-notify.yaml`) that fires when ANY watched workflow (Build, PHPStan, unit tests, cs-fixer, the nightly common bump, …) concludes `failure` on `main`. This closes the **silent nightly common-bump failure** gap (DEVEX-1398): previously a broken bump only showed as a red ✗ in the Actions tab + an email to the bot PAT owner.

## Why workflow_run (not an in-Build job)

A notify job inside Build only sees Build/deploy. The static checks (phpstan, tests, cs-fixer) run as separate workflows — their failures need a watcher that observes completed runs across the repo. One watcher per repo covers build + all checks + the bump itself.

Per-repo watcher PRs follow, each linked to DEVEX-1398.