### PR TITLE
revert: DEVEX-1653 rt_mode addition — main-path tag-and-release skipped

### DIFF
--- a/.github/workflows/build-php-v1.yaml
+++ b/.github/workflows/build-php-v1.yaml
@@ -18,16 +18,6 @@ on:
         required: false
         type: string
         default: "gha"
-      rt_mode:
-        description: |
-          Release-train mode. When true, skips mathieudutour and the trailing
-          GH Release step; the encodium/actions _compute-rt-tag composite
-          pushes the rt rc tag and creates the GH pre-release atomically up
-          front, and `build` uses that tag. Caller must trigger on rt-* refs
-          and grant `contents: write` to this job (see DEVEX-1653).
-        required: false
-        type: boolean
-        default: false
     secrets:
       packagist_username:
         required: true
@@ -37,17 +27,12 @@ on:
         required: true
     outputs:
       tag:
-        description: "The released tag (either the main vX.Y.Z tag or the rt rc tag)."
-        value: ${{ jobs.tag-and-release.outputs.tag || jobs.compute-rt-tag.outputs.tag }}
+        description: "The released tag"
+        value: ${{ jobs.tag-and-release.outputs.tag }}
 
 jobs:
-  # ─── non-rt path ────────────────────────────────────────────────────────
-  # Dry-run mathieudutour to compute what tag-and-release will emit; build
-  # uses that pre-computed value so the image tag and the eventual git tag
-  # agree. Skipped under rt_mode (the composite handles tagging atomically).
   calculate-tag:
     name: Calculate Build Tag
-    if: ${{ !inputs.rt_mode }}
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.dry_tag_version.outputs.new_tag }}
@@ -63,40 +48,9 @@ jobs:
           fetch_all_tags: true
           dry_run: true
 
-  # ─── rt-mode path ───────────────────────────────────────────────────────
-  # Single source of truth for rt rc tagging: the composite parses the
-  # rt-<YYYY-MM-DD> branch, computes the next iter, pushes the lightweight
-  # tag, and creates the GH pre-release. Build then consumes its output.
-  compute-rt-tag:
-    name: Compute RT Tag
-    if: ${{ inputs.rt_mode }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    outputs:
-      tag: ${{ steps.rt_tag.outputs.tag }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-      - id: rt_tag
-        uses: encodium/actions/.github/actions/_compute-rt-tag@main
-        with:
-          github_token: ${{ secrets.gh_token }}
-
   build:
     name: Build ${{ matrix.image.tag_prefix }}image
-    # Either calculate-tag (non-rt) or compute-rt-tag (rt) will run; the
-    # other is skipped by its branch gate. `always()` keeps build alive
-    # despite the skipped need, and the explicit success check prevents a
-    # false start if the active tag job actually failed.
-    needs: [calculate-tag, compute-rt-tag]
-    if: |
-      always() && (
-        needs.calculate-tag.result == 'success' ||
-        needs.compute-rt-tag.result == 'success'
-      )
+    needs: [calculate-tag]
     strategy:
       matrix:
         image: ${{ fromJSON(inputs.images) }}
@@ -106,9 +60,7 @@ jobs:
       image_name: ${{ matrix.image.image_name }}
       dockerfile: ${{ matrix.image.dockerfile }}
       build_target: ${{ matrix.image.target }}
-      # Skipped jobs return empty-string outputs, so `||` picks the active
-      # path's tag without further gating.
-      tag: ${{ matrix.image.tag_prefix }}${{ needs.calculate-tag.outputs.tag || needs.compute-rt-tag.outputs.tag }}
+      tag: ${{ matrix.image.tag_prefix }}${{ needs.calculate-tag.outputs.tag }}
       extra_tag: ${{ matrix.image.extra_tag }}
       cache_type: ${{ inputs.cache_type }}
     secrets:
@@ -116,13 +68,8 @@ jobs:
       packagist_password: ${{ secrets.packagist_password }}
       gh_token: ${{ secrets.gh_token }}
 
-  # ─── non-rt path (tail) ────────────────────────────────────────────────
-  # Re-runs mathieudutour (this time not dry) to actually push the tag,
-  # then creates the GH pre-release. Skipped under rt_mode — the composite
-  # already did both up front.
   tag-and-release:
     name: Github Tag and Release
-    if: ${{ !inputs.rt_mode }}
     needs: [build]
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
Reverts #137.

## Why

After merge of #137 and Batch 1 Phase 3 PRs (license_api, internal_api, rp_api, catalog_api, vin_decoder_service), all four main-builds that went through the shared build-php-v1 orchestrator FAILED at integration-deploy with empty image_tag → helm YAML crash.

Root cause: **`Github Tag and Release` job was SKIPPED** on all runs. Its condition `if: \${{ !inputs.rt_mode }}` should evaluate true when rt_mode isn't set by the caller, but empirically it's evaluating differently. `Calculate Build Tag` (same condition) DID run, so this is likely an interaction between the `needs: [build]` chain (with reusable-workflow matrix) and the untyped rt_mode input.

Reverting to unblock the 4 red main-builds (integration environment redeploys will run once next push lands on each app's main). Fix-forward under a fresh PR: add `type: boolean, default: false` to rt_mode, and verify tag-and-release fires on a canary before re-merging.

Refs DEVEX-1653.