### PR TITLE
DEVEX-1653: re-land rt_mode with transitive-skip fix

### DIFF
--- a/.github/workflows/build-php-v1.yaml
+++ b/.github/workflows/build-php-v1.yaml
@@ -18,6 +18,16 @@ on:
         required: false
         type: string
         default: "gha"
+      rt_mode:
+        description: |
+          Release-train mode. When true, skips mathieudutour and the trailing
+          GH Release step; the encodium/actions _compute-rt-tag composite
+          pushes the rt rc tag and creates the GH pre-release atomically up
+          front, and `build` uses that tag. Caller must trigger on rt-* refs
+          and grant `contents: write` to this job (see DEVEX-1653).
+        required: false
+        type: boolean
+        default: false
     secrets:
       packagist_username:
         required: true
@@ -27,12 +37,17 @@ on:
         required: true
     outputs:
       tag:
-        description: "The released tag"
-        value: ${{ jobs.tag-and-release.outputs.tag }}
+        description: "The released tag (either the main vX.Y.Z tag or the rt rc tag)."
+        value: ${{ jobs.tag-and-release.outputs.tag || jobs.compute-rt-tag.outputs.tag }}
 
 jobs:
+  # ─── non-rt path ────────────────────────────────────────────────────────
+  # Dry-run mathieudutour to compute what tag-and-release will emit; build
+  # uses that pre-computed value so the image tag and the eventual git tag
+  # agree. Skipped under rt_mode (the composite handles tagging atomically).
   calculate-tag:
     name: Calculate Build Tag
+    if: ${{ !inputs.rt_mode }}
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.dry_tag_version.outputs.new_tag }}
@@ -48,9 +63,40 @@ jobs:
           fetch_all_tags: true
           dry_run: true
 
+  # ─── rt-mode path ───────────────────────────────────────────────────────
+  # Single source of truth for rt rc tagging: the composite parses the
+  # rt-<YYYY-MM-DD> branch, computes the next iter, pushes the lightweight
+  # tag, and creates the GH pre-release. Build then consumes its output.
+  compute-rt-tag:
+    name: Compute RT Tag
+    if: ${{ inputs.rt_mode }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      tag: ${{ steps.rt_tag.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - id: rt_tag
+        uses: encodium/actions/.github/actions/_compute-rt-tag@main
+        with:
+          github_token: ${{ secrets.gh_token }}
+
   build:
     name: Build ${{ matrix.image.tag_prefix }}image
-    needs: [calculate-tag]
+    # Either calculate-tag (non-rt) or compute-rt-tag (rt) will run; the
+    # other is skipped by its branch gate. `always()` keeps build alive
+    # despite the skipped need, and the explicit success check prevents a
+    # false start if the active tag job actually failed.
+    needs: [calculate-tag, compute-rt-tag]
+    if: |
+      always() && (
+        needs.calculate-tag.result == 'success' ||
+        needs.compute-rt-tag.result == 'success'
+      )
     strategy:
       matrix:
         image: ${{ fromJSON(inputs.images) }}
@@ -60,7 +106,9 @@ jobs:
       image_name: ${{ matrix.image.image_name }}
       dockerfile: ${{ matrix.image.dockerfile }}
       build_target: ${{ matrix.image.target }}
-      tag: ${{ matrix.image.tag_prefix }}${{ needs.calculate-tag.outputs.tag }}
+      # Skipped jobs return empty-string outputs, so `||` picks the active
+      # path's tag without further gating.
+      tag: ${{ matrix.image.tag_prefix }}${{ needs.calculate-tag.outputs.tag || needs.compute-rt-tag.outputs.tag }}
       extra_tag: ${{ matrix.image.extra_tag }}
       cache_type: ${{ inputs.cache_type }}
     secrets:
@@ -68,8 +116,21 @@ jobs:
       packagist_password: ${{ secrets.packagist_password }}
       gh_token: ${{ secrets.gh_token }}
 
+  # ─── non-rt path (tail) ────────────────────────────────────────────────
+  # Re-runs mathieudutour (this time not dry) to actually push the tag,
+  # then creates the GH pre-release. Skipped under rt_mode — the composite
+  # already did both up front.
+  #
+  # !cancelled() gate: `needs: [build]` transitively inherits `build`'s
+  # own needs ([calculate-tag, compute-rt-tag]), one of which is always
+  # skipped depending on rt_mode. GitHub Actions' default `success()`
+  # gate on job-if propagates that transitive skip and silently skips
+  # this job even when build itself succeeded — verified by the failing
+  # Batch 1 run against the shared orchestrator immediately post-#137
+  # (all main-builds emitted empty image_tag → helm apply crash).
   tag-and-release:
     name: Github Tag and Release
+    if: ${{ !cancelled() && !inputs.rt_mode }}
     needs: [build]
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
Re-lands #137 (reverted in #140) with the fix for the transitive-skip cascade in `tag-and-release`.

## What broke

#137 added rt_mode support to the shared `build-php-v1` orchestrator. Immediately after merging #137 and Batch 1 Phase 3 PRs (license_api, internal_api, rp_api, catalog_api, vin_decoder_service), all four main-builds that reached integration-deploy FAILED at helm apply with:

```
Error: UPGRADE FAILED: YAML parse error on <chart>/templates/deployment.yaml: mapping values are not allowed in this context
```

Because `image_tag` was empty, helm rendered `image: ghcr.io/encodium/<repo>:` with nothing after the colon → malformed YAML.

## Root cause

`tag-and-release` was silently SKIPPED on all main-path runs, even though its condition `if: !inputs.rt_mode` and `build` itself both evaluate correctly.

The mechanism: `tag-and-release` has `needs: [build]`. `build` in turn has `needs: [calculate-tag, compute-rt-tag]`. On the main-path, `compute-rt-tag` is skipped (it's the rt-path branch). GitHub Actions' default `success()` gate on any job-if propagates the transitive skipped state through the needs chain — so tag-and-release inherits "one of my transitive needs was skipped, so I skip too" behavior even though its own direct need (`build`) succeeded.

The parallel non-`needs` job (`calculate-tag`) is unaffected because it has no transitive skipped ancestors.

## Fix

Add `!cancelled()` to tag-and-release's condition:

```yaml
tag-and-release:
  if: \${{ !cancelled() && !inputs.rt_mode }}
```

`!cancelled()` explicitly overrides the implicit success() gate, restoring intended semantics: run whenever the workflow wasn't cancelled AND we're on the non-rt path. Well-known idiom for this exact class of transitive-skip bug.

## Test plan

Post-merge, canary against license_api by pushing an empty commit to main (or letting the next merge fire). Expected: Build.yaml runs cleanly, tag-and-release actually fires this time, emits a clean `vX.Y.Z` tag, integration-deploy consumes it, helm apply succeeds.

Only after canary passes do we resume merging the remaining 10 Phase 3 PRs (Batches 3/4).

Refs DEVEX-1653, #137 (original), #140 (revert).