### PR TITLE
chore(ci): clear Node 20 deprecation warnings across shared workflows

### DIFF
--- a/.github/workflows/build-php-laravel.yaml
+++ b/.github/workflows/build-php-laravel.yaml
@@ -57,7 +57,7 @@ jobs:
         with:
           fetch-depth: 0
       - id: dry_tag_version
-        uses: mathieudutour/github-tag-action@v6.1
+        uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.gh_token }}
           release_branches: ${{ inputs.release_branches }}
@@ -94,7 +94,7 @@ jobs:
         with:
           fetch-depth: 0
       - id: tag_version
-        uses: mathieudutour/github-tag-action@v6.1
+        uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.gh_token }}
           release_branches: ${{ inputs.release_branches }}

--- a/.github/workflows/build-php-v1.yaml
+++ b/.github/workflows/build-php-v1.yaml
@@ -56,7 +56,7 @@ jobs:
         with:
           fetch-depth: 0
       - id: dry_tag_version
-        uses: mathieudutour/github-tag-action@v6.1
+        uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.gh_token }}
           release_branches: ${{ inputs.release_branches }}
@@ -140,7 +140,7 @@ jobs:
         with:
           fetch-depth: 0
       - id: tag_version
-        uses: mathieudutour/github-tag-action@v6.1
+        uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.gh_token }}
           release_branches: ${{ inputs.release_branches }}

--- a/.github/workflows/helm-deploy-eks.yaml
+++ b/.github/workflows/helm-deploy-eks.yaml
@@ -55,7 +55,7 @@ jobs:
         with:
           ref: ${{ inputs.image_tag }}
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           aws-access-key-id: ${{ secrets.aws_access_id }}
           aws-secret-access-key: ${{ secrets.aws_access_secret }}
@@ -63,9 +63,16 @@ jobs:
           role-duration-seconds: 1200
           role-session-name: GithubActions-${{ github.event.repository.name }}
       - name: Setup Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v4
+        with:
+          # token: fetches the latest Helm release from GitHub. Without it
+          # the action falls back to a hardcoded default version and emits
+          # a warning on every deploy log.
+          token: ${{ github.token }}
       - name: Setup Kubectl
-        uses: Azure/setup-kubectl@v3
+        uses: Azure/setup-kubectl@v4
+        with:
+          token: ${{ github.token }}
       - name: deploy
         run: |
           echo "${{ secrets.kubeconfig }}" >> kube.config

--- a/.github/workflows/helm-deploy.yaml
+++ b/.github/workflows/helm-deploy.yaml
@@ -58,11 +58,14 @@ jobs:
         with:
           ref: ${{ inputs.image_tag }}
       - name: Setup Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v4
         with:
           version: ${{ inputs.helm_version }}
+          token: ${{ github.token }}
       - name: Setup Kubectl
-        uses: Azure/setup-kubectl@v3
+        uses: Azure/setup-kubectl@v4
+        with:
+          token: ${{ github.token }}
       - name: deploy
         run: |
           kubectl config set-cluster k8s --server="${{ secrets.k8s_server }}"

--- a/.github/workflows/helm-deployv2.yaml
+++ b/.github/workflows/helm-deployv2.yaml
@@ -51,9 +51,13 @@ jobs:
         with:
           ref: ${{ inputs.image_tag }}
       - name: Setup Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v4
+        with:
+          token: ${{ github.token }}
       - name: Setup Kubectl
-        uses: Azure/setup-kubectl@v3
+        uses: Azure/setup-kubectl@v4
+        with:
+          token: ${{ github.token }}
       - name: deploy
         run: |
           echo "${{ secrets.kubeconfig }}" >> kube.config

--- a/.github/workflows/helm-rollback.yaml
+++ b/.github/workflows/helm-rollback.yaml
@@ -30,9 +30,13 @@ jobs:
         with:
           ref: ${{ inputs.image_tag }}
       - name: Setup Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v4
+        with:
+          token: ${{ github.token }}
       - name: Setup Kubectl
-        uses: Azure/setup-kubectl@v3
+        uses: Azure/setup-kubectl@v4
+        with:
+          token: ${{ github.token }}
       - name: deploy
         run: |
           kubectl config set-cluster k8s --server="${{ secrets.k8s_server }}"

--- a/.github/workflows/openapi-generate-javascript-client.yaml
+++ b/.github/workflows/openapi-generate-javascript-client.yaml
@@ -108,7 +108,7 @@ jobs:
           message: "${{ steps.spec.outputs.title }} ${{ steps.spec.outputs.version }}"
           tag: ${{ steps.spec.outputs.version }}
       - name: Node Setup
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
       - run: npm install
       - run: npm run build
       - uses: JS-DevTools/npm-publish@v1

--- a/.github/workflows/openapi-generate-typescript-client.yaml
+++ b/.github/workflows/openapi-generate-typescript-client.yaml
@@ -108,7 +108,7 @@ jobs:
           message: "${{ steps.spec.outputs.title }} ${{ steps.spec.outputs.version }}"
           tag: ${{ steps.spec.outputs.version }}
       - name: Node Setup
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
       - run: npm install
       - run: npm run build
       - uses: JS-DevTools/npm-publish@v1


### PR DESCRIPTION
## Summary

GitHub is forcing Node 20 actions to run on Node 24 and logs a warning on every workflow run:

\`\`\`
##[warning]Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: ...
\`\`\`

This PR bumps the actions that have Node 24 native versions and wires \`token:\` on \`azure/setup-helm\` / \`Azure/setup-kubectl\` to also eliminate the noisy \`GITHUB_TOKEN not set\` warning from every rt-* auto-deploy log.

## Bumps

| Action | From | To | Files |
|---|---|---|---|
| \`aws-actions/configure-aws-credentials\` | v4 | **v5** | helm-deploy-eks.yaml |
| \`azure/setup-helm\` | v3 | **v4** | helm-deploy-eks.yaml, helm-deploy.yaml, helm-deployv2.yaml, helm-rollback.yaml |
| \`Azure/setup-kubectl\` | v3 | **v4** | same 4 files |
| \`actions/setup-node\` | v4 | **v5** | openapi-generate-{javascript,typescript}-client.yaml |
| \`mathieudutour/github-tag-action\` | v6.1 | **v6.2** | build-php-v1.yaml, build-php-laravel.yaml |

## Token wiring

Add \`token: \${{ github.token }}\` to every \`azure/setup-helm\` and \`Azure/setup-kubectl\` invocation. Without it, both actions try to fetch the latest tool version via GitHub API, fail auth, and log a \`::warning::[@octokit/auth-action] GITHUB_TOKEN not set\` message. Deploys succeed with a hard-coded fallback version — cosmetic, but eliminates the noise.

## Deferred to follow-up

- **\`actions/upload-artifact\`** v4 → v5 has a breaking change (duplicate artifact names now error instead of warn). Used in 5 workflows — needs per-usage review before bumping.
- **\`docker/setup-buildx-action@v3\`, \`docker/login-action@v3\`, \`docker/build-push-action@v6\`** have no Node 24 upstream release yet. Wait for upstream.

## Spotted (not fixed here — worth a separate ticket)

- \`helm-rollback.yaml:31\` references \`\${{ inputs.image_tag }}\` in the checkout ref, but the workflow's inputs are \`{deployment, environment, namespace}\`. Pre-existing typo — falls through to the default ref silently. Actionlint flagged this while I was in the file.

## Verification

- \`actionlint\` clean on all 8 modified files (only pre-existing shellcheck-info noise + the helm-rollback typo above)
- Every existing \`with:\` block extended, never replaced
- No downstream breaking-change semantics on any of the bumped majors that I could find (v5s are backwards-compatible for our usage)

## Blast radius

Every RT v2 participant that runs helm-* deploys OR build-php-* orchestrators inherits these versions on next call. That's ~22 repos. Downstream failure would be visible immediately on the next deploy run.

## Related

- DEVEX-1653 (RT v2 downstream — auto-deploy noise reduction)
- DEVEX-1680 (batch Shape 1 — where the setup-helm warning was first spotted)