### PR TITLE
feat(slack-deploy-notification): include version + diff since last prod release

### DIFF
--- a/.github/workflows/slack-deploy-notification.yaml
+++ b/.github/workflows/slack-deploy-notification.yaml
@@ -28,6 +28,47 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
+      # Compute the previous production release tag by walking the GH
+      # Releases API and picking the most recent non-current, non-draft,
+      # non-prerelease entry. Callers gate this workflow on
+      # `inputs.environment == 'prod'`, so filtering out prereleases yields
+      # the previous prod release specifically. Enables a compare link in
+      # the Slack message so folks can see exactly what shipped.
+      - name: Compute previous prod release + diff link
+        id: diff
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CURRENT_TAG: ${{ inputs.image_tag }}
+        run: |
+          set -euo pipefail
+          PREV_TAG=$(gh release list \
+            --repo "${{ github.repository }}" \
+            --exclude-drafts \
+            --exclude-pre-releases \
+            --json tagName,publishedAt \
+            --limit 50 \
+            | jq -r --arg cur "$CURRENT_TAG" \
+              '[.[] | select(.tagName != $cur)] | sort_by(.publishedAt) | reverse | .[0].tagName // ""')
+          if [ -n "$PREV_TAG" ]; then
+            COMPARE_URL="${{ github.server_url }}/${{ github.repository }}/compare/${PREV_TAG}...${CURRENT_TAG}"
+            # Slack mrkdwn: leading tab preserves the indented-bullet style
+            # used by the other lines in the payload.
+            DIFF_LINE="\n\t<${COMPARE_URL}|View changes since ${PREV_TAG}>"
+            echo "Previous prod release: $PREV_TAG"
+            echo "Compare URL: $COMPARE_URL"
+          else
+            # First prod release for this repo — nothing to diff against.
+            DIFF_LINE=""
+            echo "No previous prod release found — first-time prod deploy."
+          fi
+          {
+            echo "previous_tag=$PREV_TAG"
+            echo "diff_line<<EOF"
+            printf '%s' "$DIFF_LINE"
+            echo
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Send deployment notification
         uses: slackapi/slack-github-action@v1.24.0
         env:
@@ -42,7 +83,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*${{ github.event.repository.name }} deployed by ${{ github.triggering_actor }}*\n\tView the <${{ inputs.dashboard_url }}|Deployment>\n\tView the <${{ inputs.apm_url }}|Service APM>"
+                    "text": "*${{ github.event.repository.name }} deployed by ${{ github.triggering_actor }}*\n\tVersion: `${{ inputs.image_tag }}`\n\tView the <${{ inputs.dashboard_url }}|Deployment>\n\tView the <${{ inputs.apm_url }}|Service APM>${{ steps.diff.outputs.diff_line }}"
                   },
                   "accessory": {
                     "type": "button",


### PR DESCRIPTION
## Summary

Enriches the shared prod-deploy Slack message with two things:

1. **Deployed image tag** on its own line in the message body (previously only surfaced via the accessory button, easy to miss on a quick scan)
2. **View changes since \<prev\>** link that opens a GitHub compare view between the previous prod release and the current one

## Rendered example (mrkdwn)

Before:

> **internal_api deployed by patrickdodgen**
>     View the Deployment
>     View the Service APM

After:

> **internal_api deployed by patrickdodgen**
>     Version: \`v4.7.6\`
>     View the Deployment
>     View the Service APM
>     View changes since v4.7.5

## Design

- **Scope**: prod only. Every consumer already calls this shared workflow with \`if: inputs.environment == 'prod'\`, so no new input is required. Verified via \`gh search code\` across encodium/*.
- **Previous release detection**: \`gh release list --exclude-drafts --exclude-pre-releases\` → filter out the current tag → sort by \`publishedAt\` desc → pick top. Matches the RT v2 promotion semantic (\`prerelease=false\` = shipped to prod).
- **Compare URL**: \`\${{ github.server_url }}/\${{ github.repository }}/compare/\${PREV}...\${CURRENT}\`
- **Edge cases**:
  - **First-ever prod release**: diff line omitted gracefully (no compare against nothing)
  - **Same tag redeployed** (rollback or manual redeploy): filters self out, uses the next most recent
  - **No releases API access**: fails the notify step, but the deploy itself already succeeded — cosmetic-only impact

## Blast radius

Every consumer of \`slack-deploy-notification.yaml\` picks up the change on next prod deploy. Callers observed via cross-repo search: 20+ repos including internal_api, radmin, prices-api, laravel-api-template, reporting-app, suppliers-api, payment_api, pub_buyer_api, etc.

## Verification

Once merged, the next prod deploy for any consumer will emit an enriched message. The compute step also \`echo\`s the previous tag + compare URL to the workflow run log for debugging.

## Follow-ups

- Jellyfish deploy notification (\`jellyfish-deploy-notification.yaml\`) untouched — team plans to remove that path entirely per today's conversation.

## Related

- DEVEX-1653 (RT v2)