### PR TITLE
fix(jira-ticket-check): skip on non-pull_request events

### DIFF
--- a/.github/workflows/jira-ticket-check.yaml
+++ b/.github/workflows/jira-ticket-check.yaml
@@ -40,6 +40,16 @@ on:
 jobs:
   check-jira-ticket:
     name: Verify Jira Ticket Link
+    # Only run the check on pull_request events. When this workflow is
+    # invoked from a caller that also triggers on push:main (e.g., a
+    # "Pull Request Workflow" that runs on both `pull_request` and
+    # `push` to main to reuse lint/test jobs), the squash-merge commit
+    # message often doesn't carry the ticket ID — semantic-conventional
+    # commits like `refactor(ci): …` are common and legitimate. The
+    # PR-time check already validated the ticket before the merge
+    # landed; running it again on push is redundant and produces
+    # false-negative alerts.
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

Adds `if: github.event_name == 'pull_request'` to the `check-jira-ticket` job so it doesn't fire on push events.

## Problem

Consumer repos (e.g., [encodium/manage's Pull Request Workflow](https://github.com/encodium/manage/blob/main/.github/workflows/pull-request-workflow.yaml)) reuse this shared workflow on **both** `pull_request` and `push: main` triggers to share lint/test jobs. On push:main, the squash-merge commit message often doesn't carry the Jira ticket ID — semantic-conventional commits like `refactor(ci): …` are common and legitimate — so the check produces false-negative alerts.

Reference failing run: [manage#28971802686](https://github.com/encodium/manage/actions/runs/28971802686) — merge of today's dispatch refactor PR failed the Jira check even though the PR itself was properly linked.

## Fix

Skip the check on non-pull_request events. Reasoning:

- The PR-time check already validated the ticket before the merge landed.
- Running again on the resulting main push is redundant.
- Squash-merge commit format is orthogonal to whether the branch's PR had a valid ticket link.

## Blast radius

Zero on the PR path — pull_request events still run the check exactly as before. Only reduces the false-negative rate on push:main.

## Related

- DEVEX-1653 (RT v2 — pattern of shared workflows called from multi-trigger repo pipelines)
