### PR TITLE
fix(helm): serialise deploys per (repo, env, release) to avoid helm concurrency errors

### DIFF
--- a/.github/workflows/helm-deploy-eks.yaml
+++ b/.github/workflows/helm-deploy-eks.yaml
@@ -46,6 +46,23 @@ on:
       aws_access_secret:
         required: true
 
+# Serialise deploys per (repository, environment, release_name). Two
+# `helm upgrade` calls targeting the same release cannot run concurrently
+# — helm rejects the second with "another operation (install/upgrade/
+# rollback) is in progress" (surfaced 2026-07-08 after the fire-and-
+# forget dispatch refactor decoupled deploy timing from Build timing).
+#
+# cancel-in-progress: false so the current deploy runs to completion.
+# Canceling an in-flight helm upgrade mid-flight risks leaving the
+# release in a weird state; queueing the next dispatch is safer.
+#
+# The group name is scoped to (repo, env, release_name) so unrelated
+# deploys don't block each other — a stg deploy for internal_api can
+# proceed while a stg deploy for catalog_api runs.
+concurrency:
+  group: helm-deploy-${{ github.repository }}-${{ inputs.environment }}-${{ inputs.release_name || github.event.repository.name }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/helm-deploy.yaml
+++ b/.github/workflows/helm-deploy.yaml
@@ -49,6 +49,17 @@ on:
       k8s_token:
         required: true
 
+# Serialise deploys per (repository, environment, release_name). Two
+# `helm upgrade` calls targeting the same release cannot run concurrently
+# — helm rejects the second with "another operation (install/upgrade/
+# rollback) is in progress" (surfaced 2026-07-08 on helm-deploy-eks.yaml).
+# Same treatment applied here for consistency across shared helm
+# workflows. cancel-in-progress: false so the current deploy runs to
+# completion before the next dispatch takes over.
+concurrency:
+  group: helm-deploy-${{ github.repository }}-${{ inputs.environment }}-${{ inputs.release_name || github.event.repository.name }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/helm-deployv2.yaml
+++ b/.github/workflows/helm-deployv2.yaml
@@ -42,6 +42,17 @@ on:
       kubeconfig:
         required: true
 
+# Serialise deploys per (repository, environment, release_name). Two
+# `helm upgrade` calls targeting the same release cannot run concurrently
+# — helm rejects the second with "another operation (install/upgrade/
+# rollback) is in progress" (surfaced 2026-07-08 on helm-deploy-eks.yaml).
+# Same treatment applied here for consistency across shared helm
+# workflows. cancel-in-progress: false so the current deploy runs to
+# completion before the next dispatch takes over.
+concurrency:
+  group: helm-deploy-${{ github.repository }}-${{ inputs.environment }}-${{ inputs.release_name || github.event.repository.name }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/helm-rollback.yaml
+++ b/.github/workflows/helm-rollback.yaml
@@ -21,6 +21,15 @@ on:
       k8s_token:
         required: true
 
+# Serialise rollbacks per (repository, environment, deployment) so a
+# rollback can't race with a concurrent helm operation on the same
+# release — same "another operation in progress" class of failure as
+# on helm-deploy-eks.yaml. cancel-in-progress: false because canceling
+# a rollback mid-flight would be worse than queueing.
+concurrency:
+  group: helm-deploy-${{ github.repository }}-${{ inputs.environment }}-${{ inputs.deployment }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds a workflow-level `concurrency:` block to all four shared helm workflows so two `helm upgrade`/`helm rollback` calls targeting the same release can't race. Two racing calls fail with:

```
Error: UPGRADE FAILED: another operation (install/upgrade/rollback) is in progress
```

## What surfaced this

The dispatch-refactor sweep landed today decoupled Build timing from deploy timing. Under the old `workflow_call` nesting, deploys shared Build's concurrency group and were implicitly serialized. Under fire-and-forget dispatch, Build completes immediately after triggering the deploy — so a second Build (e.g., from a common bump ~1 minute later) can start and dispatch a second deploy while the first is still running.

Two examples from earlier today, on the same shared helm-deploy-eks.yaml:

| Run | Repo | Error |
|---|---|---|
| [28972011991](https://github.com/encodium/listings-url-service/actions/runs/28972011991) | listings-url-service | UPGRADE FAILED: another operation in progress |
| [28971997409](https://github.com/encodium/returns-api/actions/runs/28971997409) | returns-api | same |

Both were second-in-sequence deploys triggered by common bumps that landed within a minute of the first push.

## Fix

Workflow-level concurrency on each of the four shared helm workflows:

```yaml
concurrency:
  group: helm-deploy-${{ github.repository }}-${{ inputs.environment }}-${{ inputs.release_name || github.event.repository.name }}
  cancel-in-progress: false
```

- **Scope**: `(repository, environment, release_name)`. Unrelated deploys don't block each other — a stg deploy for internal_api can run while a stg deploy for catalog_api runs.
- **`cancel-in-progress: false`**: The current deploy runs to completion. Canceling an in-flight helm upgrade risks leaving the release in an inconsistent state; queueing the next dispatch is safer.

Applied to all four shared helm workflows:

- `helm-deploy-eks.yaml` (primary EKS deploy — the one actively failing)
- `helm-deploy.yaml` (older path, still used by daemon-template, reporting-app, laravel-api-template)
- `helm-deployv2.yaml` (used by pub_vehicle_api, prices-api, daemon-template)
- `helm-rollback.yaml` (uses `deployment` input instead of `release_name`)

## Blast radius

Zero when there's no concurrency contention — deploys run exactly as before. When there IS contention on the same `(repo, env, release)`, the second dispatch queues and waits (up to GitHub's default 6-hour timeout, but real deploys complete in minutes) instead of failing.

## Verification

Once merged, the next scenario where two dispatches land within seconds of each other targeting the same release will exercise the queue. The queued run's Actions UI will show it as "queued behind another workflow run" until the first finishes.

## Related

- Dispatch-refactor sweep (batch#8562 + 17 companion PRs, all merged 2026-07-08)
- DEVEX-1653 (RT v2)