### PR TITLE
DEVEX-1687: raise helm client QPS/burst to stop rate-limiter deploy failures

### DIFF
--- a/.github/workflows/helm-deploy-eks.yaml
+++ b/.github/workflows/helm-deploy-eks.yaml
@@ -91,6 +91,17 @@ jobs:
         with:
           token: ${{ github.token }}
       - name: deploy
+        # Raise helm's client-side API rate limits. `helm upgrade --wait`
+        # polls the status of every object in the release on a loop; large
+        # releases (e.g. webstore: ~90+ pods + deployments/services/ingress)
+        # exceed helm's low default QPS and the client-go rate limiter errors
+        # with "client rate limiter Wait returned an error: rate: Wait(n=1)
+        # would exceed context deadline", failing an otherwise-healthy deploy
+        # (webstore prod, 2026-07-09, DEVEX-1687). The API server's own
+        # Priority & Fairness still protects it; this only relaxes the client.
+        env:
+          HELM_QPS: "50"
+          HELM_BURST_LIMIT: "300"
         run: |
           echo "${{ secrets.kubeconfig }}" >> kube.config
           export KUBECONFIG=./kube.config


### PR DESCRIPTION
## Problem

`helm upgrade --wait` (used by every service deploying through `helm-deploy-eks.yaml`) polls the status of **every object in the release** on a loop. For large releases this exceeds helm's low default client-side QPS, and `client-go`'s rate limiter aborts status computation with:

```
failed to compute object status: <deploy>: client rate limiter Wait returned an error: rate: Wait(n=1) would exceed context deadline
```

This fails an **otherwise-healthy** deploy and, with `atomic: true`, triggers an auto-rollback of a good release. Observed on **webstore prod on 2026-07-09** (~90+ pods + deployments/services/ingress in one release): the paced rollout reached full availability, but helm's `--wait` never returned and a prior attempt's rollback failed outright with the error above (DEVEX-1687).

## Change

Set `HELM_QPS=50` and `HELM_BURST_LIMIT=300` as env on the `deploy` step. Helm exposes these exactly for this case (`helm --help`: *"set the Queries Per Second in cases where a high number of calls exceed the operations…"*, *"burst limit in the case the server contains many CRDs"*).

This only relaxes the **client-side** limiter. The Kubernetes API server's own API Priority & Fairness still throttles/protects it, so there's no risk of overwhelming the control plane.

## Scope / blast radius

Shared workflow — applies to all consumers. That's intended: it's a safe, uniform raise of a client-side limit that's too low for larger releases, and a no-op for small ones (they never approach the default ceiling).

## Confidence

The rate-limiter error is a **confirmed** failure mode (recorded in the webstore rev-400 release record), not inferred. The related `--wait` hang on the same release is strongly consistent with the same cause (availability was stable at full replicas for minutes while helm never returned). If a future large deploy still hangs after this, it points to a second factor to investigate.

## Related

- webstore rollout-pacing fix: encodium/webstore#4666 (DEVEX-1687)