### PR TITLE
DEVEX-1653: badge prod deploys as 🚂 RT or ⚡ Hotfix for P0 triage

### DIFF
--- a/.github/workflows/slack-deploy-notification.yaml
+++ b/.github/workflows/slack-deploy-notification.yaml
@@ -28,6 +28,41 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
+      # Classify the deploy as Release Train (rt) or Hotfix based on the
+      # image tag shape. RT deploys tag `vX.Y.Z-rc.YYYY-MM-DD.N` — the rc
+      # suffix with a train-date is the tell. Everything else (plain
+      # `vX.Y.Z` main deploys, feature-branch tags, ad-hoc) is treated
+      # as a hotfix / out-of-band deploy.
+      #
+      # Rationale (Peace Room 2026-07-09): during P0 triage the team needs
+      # to quickly spot which prod deploys skipped the RT sign-off flow,
+      # since hotfixes see less scrutiny and are more likely culprits.
+      # This runs unconditionally because the workflow is prod-only by
+      # structural design — callers only invoke it from prod deploy
+      # paths (deploy-eks.yaml → slack-notification), so every message
+      # emitted here is a prod message.
+      - name: Classify deploy type
+        id: type
+        env:
+          IMAGE_TAG: ${{ inputs.image_tag }}
+        run: |
+          set -euo pipefail
+          if [[ "$IMAGE_TAG" =~ -rc\.[0-9]{4}-[0-9]{2}-[0-9]{2}\.[0-9]+$ ]]; then
+            BADGE_MRKDWN="🚂 *RT*"
+            BADGE_TEXT="🚂 RT"
+            CLASSIFICATION="release-train"
+          else
+            BADGE_MRKDWN="⚡ *Hotfix*"
+            BADGE_TEXT="⚡ Hotfix"
+            CLASSIFICATION="hotfix"
+          fi
+          echo "Classified $IMAGE_TAG as $CLASSIFICATION"
+          {
+            echo "badge_mrkdwn=$BADGE_MRKDWN"
+            echo "badge_text=$BADGE_TEXT"
+            echo "classification=$CLASSIFICATION"
+          } >> "$GITHUB_OUTPUT"
+
       # Compute the previous production release tag by walking the GH
       # Releases API and picking the most recent non-current, non-draft,
       # non-prerelease entry. Callers gate this workflow on
@@ -77,13 +112,13 @@ jobs:
         with:
           payload: |
             {
-              "text": "${{ github.event.repository.name }} deployed",
+              "text": "${{ steps.type.outputs.badge_text }} · ${{ github.event.repository.name }} deployed",
               "blocks": [
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*${{ github.event.repository.name }} deployed by ${{ github.triggering_actor }}*\n\tVersion: `${{ inputs.image_tag }}`\n\tView the <${{ inputs.dashboard_url }}|Deployment>\n\tView the <${{ inputs.apm_url }}|Service APM>${{ steps.diff.outputs.diff_line }}"
+                    "text": "${{ steps.type.outputs.badge_mrkdwn }} · *${{ github.event.repository.name }} deployed by ${{ github.triggering_actor }}*\n\tVersion: `${{ inputs.image_tag }}`\n\tView the <${{ inputs.dashboard_url }}|Deployment>\n\tView the <${{ inputs.apm_url }}|Service APM>${{ steps.diff.outputs.diff_line }}"
                   },
                   "accessory": {
                     "type": "button",


### PR DESCRIPTION
## Context

Peace Room ask (2026-07-09): during P0 triage the team needs to spot which prod deploys skipped the RT sign-off flow. Hotfixes see less scrutiny and are more likely culprits, but today the `#releases` notification looks identical for every prod deploy regardless of whether it came from the Thursday train or a direct-to-main dispatch. Wall of undifferentiated deploys is bad for triage speed.

## Change

Adds a `Classify deploy type` step ahead of send-notification. Detection is pure regex on `inputs.image_tag` — no new inputs, no per-caller changes.

**Rule:** tag matches `-rc.YYYY-MM-DD.N` → `🚂 RT`. Everything else → `⚡ Hotfix`.

Verified against real tags from rt-2026-07-09 promote:

| Tag | Classification |
| --- | --- |
| `v0.440.10-rc.2026-07-09.7` | 🚂 RT |
| `v4.7.0-rc.2026-06-18.3` | 🚂 RT |
| `v12.221.30-rc.2026-06-18.2` | 🚂 RT (common) |
| `v0.440.6-SHOP-5177-revert-ssr-sidecar.0` | ⚡ Hotfix |
| `v0.439.9` | ⚡ Hotfix |
| `v1.0.0` | ⚡ Hotfix |

## Message before / after

**Before:**
```
*webstore deployed by pdodgen*
    Version: `v0.440.10-rc.2026-07-09.7`
    View the Deployment
    View the Service APM
    View changes since v0.440.6-SHOP-5177-revert-ssr-sidecar.0
```

**After (RT):**
```
🚂 *RT* · *webstore deployed by pdodgen*
    Version: `v0.440.10-rc.2026-07-09.7`
    …
```

**After (Hotfix):**
```
⚡ *Hotfix* · *webstore deployed by pdodgen*
    Version: `v0.440.10`
    …
```

Fallback `text` field (used for mobile notifications + screen readers) also gets the badge as plain text (`🚂 RT · webstore deployed`).

## Scoping notes

- **Prod-only by structural design:** this workflow is only invoked from prod deploy paths (deploy-eks.yaml → slack-notification). No env input, no gate needed — every message emitted here is a prod message. QA and staging notifications are unaffected.
- **Jellyfish parser compatibility:** per the earlier dual-tag-format work, the parser anchors on the Version line and repo name — not the header prefix. Added badge doesn't touch either. Safe.
- **Non-RT repos** (radmin, etc.): technically will show `⚡ Hotfix` on every deploy since they never emit rc tags. Discussed and accepted — the label is honest (they're out-of-RT-process) and the badge cost is zero for repos that aren't triage-critical.

## Verification plan

Once merged, watch `#releases` for the next RT-participant deploy (any env change) and confirm the badge renders correctly. If a rendering issue surfaces on mobile Slack, easy to iterate.