### PR TITLE
DEVEX-1653: declare on_rt input on slack-deploy-notification (unblock sweep)

### DIFF
--- a/.github/workflows/slack-deploy-notification.yaml
+++ b/.github/workflows/slack-deploy-notification.yaml
@@ -20,6 +20,19 @@ on:
         required: false
         type: string
         default: "https://app.datadoghq.com/services?env=production"
+      on_rt:
+        # Accepted but not yet consumed by the classifier — the current
+        # step below still uses tag-shape inference. This input is
+        # declared now so the 21 DEVEX-1653 sweep PRs (which pass
+        # `on_rt: ${{ inputs.on_rt }}` from each participant's deploy
+        # chain) don't hit "invalid input" once they land. A follow-up
+        # PR flips the classifier to bright-line `on_rt=true → 🚂 RT,
+        # else → ⚡ Hotfix` and drops the tag-inference fallback, after
+        # rt-promote.sh is updated to pass `-f on_rt=true`.
+        description: "true only when the deploy is dispatched by rt-promote.sh (coordinated train promote). Default false = hotfix / out-of-band. Reserved for use once the DEVEX-1653 sweep completes."
+        type: boolean
+        default: false
+        required: false
     secrets:
       slack_webhook_url:
         required: true


### PR DESCRIPTION
## Context

The DEVEX-1653 `on_rt` sweep opened 21 draft PRs (webstore [#4670](https://github.com/encodium/webstore/pull/4670) + 20 subagent-opened sibling PRs on the other RT participants + shipments-api [#373](https://github.com/encodium/shipments-api/pull/373) which contains a fresh `deploy-production.yaml`). Every one of them passes `on_rt` through to this workflow:

- Shape A/B repos: `deploy-production.yaml` → `deploy-eks.yaml` → `slack-deploy-notification.yaml` with `on_rt: ${{ inputs.on_rt }}`
- Shape C repos: `deploy-production.yaml` → `slack-deploy-notification.yaml` with `on_rt: ${{ github.event.inputs.on_rt == 'true' }}`

Ordering gap I missed when opening the sweep: this workflow didn't declare `on_rt` as a workflow_call input. If any sweep PR merged first, its prod deploys would fail with "invalid input: on_rt" on the slack-notification step.

## What this PR does

Declares `on_rt` as an optional workflow_call input (default false). **The classifier step is unchanged** — still uses tag-shape inference (`-rc.YYYY-MM-DD.N` = 🚂 RT, else = ⚡ Hotfix). The input is accepted but not yet consumed by the badge logic.

Current Slack badge behavior is preserved exactly.

## Follow-up (once sweep merges + rt-promote.sh updates)

A separate coordinated pair of PRs will:

1. `encodium/.github`: flip classifier to bright-line rule — `if on_rt=true → 🚂 RT, else → ⚡ Hotfix`. Drops tag-inference fallback.
2. `encodium/actions`: update `rt-promote.sh` in captain handbook to dispatch each deploy with `-f on_rt=true`.

That fixes Sam's 2026-07-09 rc.8 case where a hotfix backport mis-badged as 🚂 RT.

## Merge safety

- Unaffected: every existing caller that doesn't pass `on_rt` (default false).
- Unaffected: every Slack message currently in flight or emitted after merge (classifier unchanged).
- Unblocked: the 21 sweep PRs — safe to merge in any order once this lands.

Small blast radius, easy to eyeball. Ready for review.