### PR TITLE
fix(commit-lint): gate on pull_request events only (same pattern as jira-ticket-check)

### DIFF
--- a/.github/workflows/git-commit-lint.yaml
+++ b/.github/workflows/git-commit-lint.yaml
@@ -10,6 +10,30 @@ on:
 jobs:
   commitlint:
     name: commit-lint
+    # Gate on pull_request events only. Callers typically invoke this
+    # from a pull-request-workflow.yaml that fires on both `pull_request`
+    # AND `push:main` (so PR CI and post-merge CI share config), but
+    # commit-lint on push:main is a false-negative machine:
+    #
+    #   * The PR's commits were already commit-linted at PR time — this
+    #     re-run adds no new signal.
+    #   * The squash-merge produces a NEW commit whose subject comes from
+    #     the PR title (per GitHub's default squash behavior). Per the
+    #     org PR-title convention (`<TICKET-ID>: <terse description>`,
+    #     see @revolutionparts/dotfiles CLAUDE.md), that subject starts
+    #     with a Jira ticket ID, not a conventional-commits type prefix
+    #     (`feat:`, `ci:`, `fix:` …). commitlint's config-conventional
+    #     rejects it, the check goes red on main, and the shared
+    #     ci-failure-notify chain (DEVEX-1398) posts a "check failed on
+    #     main" alert to #releases that looks like a build failure but
+    #     is actually cosmetic.
+    #
+    # Fix: skip on push. Same gate we applied to jira-ticket-check.yaml
+    # (DEVEX-1653 follow-up, .github#144). If we ever want to enforce
+    # commitlint on the squash-merge subject too, the right move is to
+    # change the PR-title convention org-wide — not to keep re-running
+    # the check where it always fires false-negatives.
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Symptom

encodium/manage run [29053841708](https://github.com/encodium/manage/actions/runs/29053841708) — squash-merge of encodium/manage#7671 (DEVEX-1653 on_rt sweep) landed on main. The Pull Request Workflow re-fired on `push:main`, and `commit-lint` came back red:

- Squash commit subject: `DEVEX-1653: thread on_rt input through deploy chain for Slack RT/Hotfix badge` (taken from PR title per GitHub's default squash behavior)
- commitlint config-conventional: rejects — the subject starts with a Jira ticket ID, not a conventional type prefix (`feat:`, `fix:`, `ci:`, …)
- The failed check triggered the shared ci-failure-notify chain (DEVEX-1398) → `#releases` got a "check failed on main" alert that looks like a build failure but is actually cosmetic

Every squash-merge from any repo using the org PR-title convention (`<TICKET-ID>: <terse description>`) hits this. Manage is just the most visible because it merges frequently.

## Fix

Add `if: github.event_name == 'pull_request'` to the `commitlint` job in the shared `git-commit-lint.yaml`. Same pattern I landed on `jira-ticket-check.yaml` in [.github#144](https://github.com/encodium/.github/pull/144). On push:main the check skips (yellow), no false-negative fires.

## Why not enforce commitlint on the squash-merge subject

Two paths considered:

- **Fix the check** (this PR): commit-lint on push:main adds no new signal — the PR's original commits were already commit-linted at PR time. The squash-merge subject is a mechanical concatenation from the PR title, not a human-authored commit. Re-checking it fires false-negatives whenever the org PR-title convention doesn't match commitlint's rules.
- **Fix the convention**: change PR-title convention org-wide to include a conventional type prefix (e.g. `feat: DEVEX-1653 thread on_rt…`). Breaks existing muscle memory + tooling, doesn't add value.

Path 1 is cheaper and matches the pattern we established for jira-ticket-check.

## Verification

Next squash-merge to any repo using this workflow. The `commit-lint` job should render as skipped (yellow) on push:main, not failed (red). PR-time commit-lint on `pull_request` events is unchanged.