### PR TITLE
fix(rt-v1): restore jellyfish-deploy-notification as no-op stub

### DIFF
--- a/.github/workflows/jellyfish-deploy-notification.yaml
+++ b/.github/workflows/jellyfish-deploy-notification.yaml
@@ -1,0 +1,50 @@
+name: Jellyfish Deploy Notification (retired)
+# RETIRED 2026-07-10 (DEVEX-1653). The org no longer uses Jellyfish for
+# deploy tracking. The original workflow was deleted in
+# encodium/.github#152 (a3b0afca) after per-repo `jellyfish-notify` jobs
+# were scrubbed across all 22 RT participants.
+#
+# This file is a NO-OP stub. It exists only so that long-lived branches
+# (feature branches, hotfix-*, dependabot bumps, in-flight PRs) cut
+# BEFORE the delete don't fail `workflow_dispatch` startup validation.
+# GH walks the reusable-workflow tree even for jobs gated `if:` off, so
+# a stale reference here caused startup_failure on any dispatched run
+# whose branch still referenced the shared workflow.
+#
+# The stub matches the retired workflow's input/secret signature exactly
+# so callers resolve cleanly. The job body does nothing except log a
+# deprecation note. No Jellyfish API call, no side effects, no failure.
+#
+# Once every branch across the org has cycled through main (rebased or
+# merged and picked up the sweep from encodium/.github#152), this stub
+# can be deleted for real. Rough guideline: ~1 month of natural branch
+# churn should be enough for anything actively worked on.
+#
+# Related:
+# - The 22-participant sweep that removed `jellyfish-notify` jobs from
+#   every RT participant landed 2026-07-10.
+# - Surfaced by encodium/internal_api run 29114404344 on hotfix-SHOP-5216.
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        type: string
+        required: true
+      image_tag:
+        type: string
+        required: true
+    secrets:
+      jellyfish_api_token:
+        required: true
+
+jobs:
+  notify-jellyfish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deprecated — stub only
+        env:
+          IMAGE_TAG: ${{ inputs.image_tag }}
+          ENVIRONMENT: ${{ inputs.environment }}
+        run: |
+          echo "::notice title=Jellyfish integration retired::This shared workflow is a no-op stub. The org no longer uses Jellyfish for deploy tracking (DEVEX-1653, retired 2026-07-10). Called from ${{ github.repository }} for image_tag=$IMAGE_TAG to $ENVIRONMENT. Consider removing the jellyfish-notify job from this caller's workflow to get rid of this warning."


### PR DESCRIPTION
## Symptom

encodium/internal_api run [29114404344](https://github.com/encodium/internal_api/actions/runs/29114404344) — hotfix-SHOP-5216 `workflow_dispatch` → `startup_failure`.

Root cause: `hotfix-SHOP-5216` was cut from main BEFORE today's sweep merged. Its `deploy-eks.yaml` (line 27) still has `uses: encodium/.github/.github/workflows/jellyfish-deploy-notification.yaml@main`. GH runs startup validation over the entire reusable-workflow tree even for jobs that would be `if:`-gated off. Since I deleted the shared workflow in [#152](https://github.com/encodium/.github/pull/152) (a3b0afca), tree resolution fails before any job runs.

Every long-lived branch across the org that predates the sweep (feature branches, hotfix-\*, dependabot PRs, in-flight work) has the same footgun.

## Fix (this PR)

Restore `jellyfish-deploy-notification.yaml` as a **no-op stub**:
- Same `workflow_call` input + secret signature as the deleted original → callers resolve cleanly
- Job body does nothing except log a deprecation `::notice::` pointing at the retirement history
- No API call to Jellyfish. No side effects. Never fails.

Long-lived branches stop hitting `startup_failure` immediately.

## Not this PR — the retirement itself stands

- All 22 participant sweep PRs stay merged
- Per-repo `jellyfish-notify` job removals stay in place
- Deletion of Jellyfish call itself in encodium/.github#152 is effectively preserved (the stub doesn't call Jellyfish)

## Delete-for-real timeline

Once org-wide branch churn has cycled through (rough guideline: ~1 month), delete this stub in a follow-up. Anything actively worked on will have naturally rebased/merged and dropped the stale reference.