### PR TITLE
chore(rt-v1): flip shared orchestrator release_branches default to main

### DIFF
--- a/.github/workflows/build-php-laravel.yaml
+++ b/.github/workflows/build-php-laravel.yaml
@@ -33,7 +33,7 @@ on:
       release_branches:
         required: false
         type: string
-        default: "stage,hotfix,rc"
+        default: "main"
     secrets:
       packagist_username:
         required: true

--- a/.github/workflows/build-php-v1.yaml
+++ b/.github/workflows/build-php-v1.yaml
@@ -13,7 +13,7 @@ on:
       release_branches:
         required: false
         type: string
-        default: "stage,hotfix,rc"
+        default: "main"
       cache_type:
         required: false
         type: string


### PR DESCRIPTION
Both `build-php-v1.yaml` and `build-php-laravel.yaml` had `release_branches` default of `stage,hotfix,rc` — RT v1 muscle memory (mathieudutour treats those branches as release-emitting).

Every Template A / laravel caller (accounts-api, catalog_api, internal_api, license_api, listings-url-service, returns-api, rp_api, vin_decoder_service) explicitly overrides with `release_branches: main`, so the default was dead weight. Flipping to `main` preserves current behavior (nobody depends on the old default) and stops advertising a v1 concept to future callers.