### PR TITLE
fix(helm-deploy-eks): pass makeLatest=legacy so GH re-evaluates latest on prod

### DIFF
--- a/.github/workflows/helm-deploy-eks.yaml
+++ b/.github/workflows/helm-deploy-eks.yaml
@@ -140,3 +140,21 @@ jobs:
           prerelease: false
           allowUpdates: true
           omitBodyDuringUpdate: true
+          # DEVEX-1655 (2026-07-13): explicitly set makeLatest=legacy so
+          # GitHub re-evaluates the "latest release" designation on this
+          # PATCH. Per GH REST docs, if `make_latest` is not defined on
+          # an update, "the release will not be reevaluated" — the
+          # previous latest sticks. The ncipollo action documents
+          # `legacy` as its default but doesn't actually pass the field
+          # when the input is omitted, so we hit the "no reevaluation"
+          # case.
+          #
+          # `legacy` = "determine based on release creation date and
+          # higher semantic version," which is the semantic we want for
+          # RT v2: every promoted rc becomes latest if it's semver-higher
+          # than the previous latest. A rollback deploy of an older rc
+          # will correctly leave the newer rc as latest.
+          #
+          # Surfaced 2026-07-13 on encodium/batch — rc.9 stayed pinned as
+          # "latest" after rc.10/11/12 were successfully promoted.
+          makeLatest: legacy


### PR DESCRIPTION
## Symptom

encodium/batch's releases page shows an older rc as 'latest' even though newer rc iters were successfully promoted to prod after it (all have `prerelease: false`).

## Root cause

GitHub REST `PATCH /releases/{id}` only reevaluates the 'latest' designation if the request explicitly includes `make_latest`. Per GH docs: *'If not defined, the release will not be reevaluated.'*

The ncipollo/release-action documents `makeLatest: legacy` as its default, but when the input is omitted it doesn't include the field in the outgoing PATCH — so we hit the no-reevaluation case. Every promoted rc keeps the flag from the FIRST one that had it, regardless of what came after.

## Fix

Pass `makeLatest: legacy` explicitly. GitHub then re-evaluates on every prod deploy:
- rc.9 promoted first → latest
- rc.10 promoted → GH sees rc.10 > rc.9 by semver → rc.10 becomes latest
- rc.11 promoted → rc.11 becomes latest
- rc.12 promoted → rc.12 becomes latest

Rollback safety: `legacy` NEVER downgrades. If prod is on rc.12 and someone deploys rc.7 as a rollback, GH sees rc.7 < rc.12 and leaves rc.12 as latest. That's the semantic we want.

## Companion

A one-time API repair of encodium/batch's current state is planned to nudge GH into re-evaluating rc.12 — not part of this PR.