### PR TITLE
[PLAT-5055] Add with_valkey_glide option to PHP CI workflows

### DIFF
--- a/.github/actions/install-valkey-glide/action.yml
+++ b/.github/actions/install-valkey-glide/action.yml
@@ -46,6 +46,6 @@ runs:
         export PATH="$HOME/.cargo/bin:$PATH"
         curl -fsSL -o /tmp/valkey_glide.tgz \
           "https://github.com/valkey-io/valkey-glide-php/releases/download/v${{ inputs.version }}/valkey_glide-${{ inputs.version }}.tgz"
-        sudo env HOME="$HOME" CARGO_HOME="$HOME/.cargo" PATH="$PATH" pecl install /tmp/valkey_glide.tgz
+        yes '' | sudo env HOME="$HOME" CARGO_HOME="$HOME/.cargo" PATH="$PATH" pecl install /tmp/valkey_glide.tgz
         echo "extension=valkey_glide.so" | sudo tee "$(php -r 'echo PHP_CONFIG_FILE_SCAN_DIR;')/99-valkey_glide.ini"
         rm -f /tmp/valkey_glide.tgz

--- a/.github/actions/install-valkey-glide/action.yml
+++ b/.github/actions/install-valkey-glide/action.yml
@@ -46,6 +46,6 @@ runs:
         export PATH="$HOME/.cargo/bin:$PATH"
         curl -fsSL -o /tmp/valkey_glide.tgz \
           "https://github.com/valkey-io/valkey-glide-php/releases/download/v${{ inputs.version }}/valkey_glide-${{ inputs.version }}.tgz"
-        yes '' | sudo env HOME="$HOME" CARGO_HOME="$HOME/.cargo" PATH="$PATH" pecl install /tmp/valkey_glide.tgz
+        yes '' | sudo env HOME="$HOME" CARGO_HOME="$HOME/.cargo" PATH="$PATH" pecl install /tmp/valkey_glide.tgz || [[ $? -eq 141 ]]
         echo "extension=valkey_glide.so" | sudo tee "$(php -r 'echo PHP_CONFIG_FILE_SCAN_DIR;')/99-valkey_glide.ini"
         rm -f /tmp/valkey_glide.tgz

--- a/.github/actions/install-valkey-glide/action.yml
+++ b/.github/actions/install-valkey-glide/action.yml
@@ -1,0 +1,51 @@
+name: Install Valkey GLIDE extension
+description: Install valkey_glide PHP extension from a GitHub release tarball
+
+inputs:
+  version:
+    description: Valkey GLIDE PHP release version
+    required: false
+    default: "1.1.2"
+
+runs:
+  using: composite
+  steps:
+    - name: Install valkey_glide build dependencies
+      shell: bash
+      run: |
+        sudo apt-get update -y
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+          build-essential \
+          git \
+          libffi-dev \
+          pkg-config \
+          python3 \
+          libprotobuf-c-dev \
+          libssl-dev \
+          protobuf-compiler \
+          protobuf-c-compiler
+
+    - name: Install Rust toolchain and cbindgen
+      shell: bash
+      run: |
+        if ! command -v cargo >/dev/null 2>&1; then
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        fi
+        . "$HOME/.cargo/env"
+        export PATH="$HOME/.cargo/bin:$PATH"
+        rustup default stable
+        if ! command -v cbindgen >/dev/null 2>&1; then
+          cargo install cbindgen
+        fi
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+    - name: Install valkey_glide
+      shell: bash
+      run: |
+        . "$HOME/.cargo/env"
+        export PATH="$HOME/.cargo/bin:$PATH"
+        curl -fsSL -o /tmp/valkey_glide.tgz \
+          "https://github.com/valkey-io/valkey-glide-php/releases/download/v${{ inputs.version }}/valkey_glide-${{ inputs.version }}.tgz"
+        sudo env HOME="$HOME" CARGO_HOME="$HOME/.cargo" PATH="$PATH" pecl install /tmp/valkey_glide.tgz
+        echo "extension=valkey_glide.so" | sudo tee "$(php -r 'echo PHP_CONFIG_FILE_SCAN_DIR;')/99-valkey_glide.ini"
+        rm -f /tmp/valkey_glide.tgz

--- a/.github/workflows/php-cs-fixer.yaml
+++ b/.github/workflows/php-cs-fixer.yaml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Install Valkey GLIDE extension
         if: ${{ inputs.with_valkey_glide }}
-        uses: ./.github/actions/install-valkey-glide
+        uses: encodium/.github/.github/actions/install-valkey-glide@PLAT-5055-valkey-glide-ci
 
       - name: Cache PHP CS Fixer
         uses: actions/cache@v5

--- a/.github/workflows/php-cs-fixer.yaml
+++ b/.github/workflows/php-cs-fixer.yaml
@@ -23,6 +23,11 @@ on:
         required: false
         type: string
         default: "chore(php-cs-fixer): fix code style issues"
+      with_valkey_glide:
+        description: "Install valkey_glide PHP extension before composer install"
+        required: false
+        type: boolean
+        default: false
     secrets:
       packagist_username:
         required: true
@@ -35,14 +40,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-        with:
-          ref: ${{ github.head_ref }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ inputs.php_version }}"
           tools: composer:v2
+
+      - name: Install Valkey GLIDE extension
+        if: ${{ inputs.with_valkey_glide }}
+        uses: ./.github/actions/install-valkey-glide
 
       - name: Cache PHP CS Fixer
         uses: actions/cache@v5

--- a/.github/workflows/php-cs-fixer.yaml
+++ b/.github/workflows/php-cs-fixer.yaml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Install Valkey GLIDE extension
         if: ${{ inputs.with_valkey_glide }}
-        uses: encodium/.github/.github/actions/install-valkey-glide@PLAT-5055-valkey-glide-ci
+        uses: encodium/.github/.github/actions/install-valkey-glide@main
 
       - name: Cache PHP CS Fixer
         uses: actions/cache@v5

--- a/.github/workflows/php-laravel-test.yaml
+++ b/.github/workflows/php-laravel-test.yaml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Install Valkey GLIDE extension
         if: ${{ inputs.with_valkey_glide }}
-        uses: encodium/.github/.github/actions/install-valkey-glide@PLAT-5055-valkey-glide-ci
+        uses: encodium/.github/.github/actions/install-valkey-glide@main
 
       - name: Install composer dependencies
         uses: ramsey/composer-install@v2

--- a/.github/workflows/php-laravel-test.yaml
+++ b/.github/workflows/php-laravel-test.yaml
@@ -30,6 +30,11 @@ on:
         type: string
         required: false
         default: ""
+      with_valkey_glide:
+        description: "Install valkey_glide PHP extension before composer install"
+        required: false
+        type: boolean
+        default: false
     secrets:
       packagist_username:
         required: true
@@ -67,6 +72,10 @@ jobs:
 
       - name: Setup problem matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Install Valkey GLIDE extension
+        if: ${{ inputs.with_valkey_glide }}
+        uses: ./.github/actions/install-valkey-glide
 
       - name: Install composer dependencies
         uses: ramsey/composer-install@v2

--- a/.github/workflows/php-laravel-test.yaml
+++ b/.github/workflows/php-laravel-test.yaml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Install Valkey GLIDE extension
         if: ${{ inputs.with_valkey_glide }}
-        uses: ./.github/actions/install-valkey-glide
+        uses: encodium/.github/.github/actions/install-valkey-glide@PLAT-5055-valkey-glide-ci
 
       - name: Install composer dependencies
         uses: ramsey/composer-install@v2

--- a/.github/workflows/php-stan.yaml
+++ b/.github/workflows/php-stan.yaml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Install Valkey GLIDE extension
         if: ${{ inputs.with_valkey_glide }}
-        uses: encodium/.github/.github/actions/install-valkey-glide@PLAT-5055-valkey-glide-ci
+        uses: encodium/.github/.github/actions/install-valkey-glide@main
 
       - name: Install composer dependencies
         uses: ramsey/composer-install@v2

--- a/.github/workflows/php-stan.yaml
+++ b/.github/workflows/php-stan.yaml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Install Valkey GLIDE extension
         if: ${{ inputs.with_valkey_glide }}
-        uses: ./.github/actions/install-valkey-glide
+        uses: encodium/.github/.github/actions/install-valkey-glide@PLAT-5055-valkey-glide-ci
 
       - name: Install composer dependencies
         uses: ramsey/composer-install@v2

--- a/.github/workflows/php-stan.yaml
+++ b/.github/workflows/php-stan.yaml
@@ -31,6 +31,11 @@ on:
         required: false
         type: string
         default: "ubuntu-latest"
+      with_valkey_glide:
+        description: "Install valkey_glide PHP extension before composer install"
+        required: false
+        type: boolean
+        default: false
     secrets:
       packagist_username:
         required: true
@@ -51,8 +56,15 @@ jobs:
           coverage: none
           php-version: ${{ inputs.php_version }}
           tools: composer
+
+      - name: Install Valkey GLIDE extension
+        if: ${{ inputs.with_valkey_glide }}
+        uses: ./.github/actions/install-valkey-glide
+
+      - name: Install composer dependencies
+        uses: ramsey/composer-install@v2
         env:
-          COMPOSER_AUTH_JSON: |
+          COMPOSER_AUTH: |
             {
               "http-basic": {
                 "repo.packagist.com": {
@@ -61,9 +73,6 @@ jobs:
                 }
               }
             }
-
-      - name: Install composer dependencies
-        uses: ramsey/composer-install@v2
 
       - name: Restore PHPStan Cache
         uses: actions/cache/restore@v4


### PR DESCRIPTION
## Summary
- Add shared `install-valkey-glide` composite action for CI runners
- Add optional `with_valkey_glide` input to `php-stan`, `php-cs-fixer`, and `php-laravel-test` reusable workflows
- Fix `php-stan` Packagist auth by moving credentials to `COMPOSER_AUTH` on `composer-install`
- Remove `github.head_ref` checkout override from `php-cs-fixer` (breaks fork PRs; lint-only workflows do not need it)

https://revolutionparts.atlassian.net/browse/PLAT-5055

## Test plan
- [ ] Merge and verify common PR #14669 CI passes with `@PLAT-5055-valkey-glide-ci` refs
- [ ] After merge, update common to `@main` and re-run CI


Made with [Cursor](https://cursor.com)