### PR TITLE
[PLAT-5055] Fix pecl install step failing after successful build

### DIFF
--- a/.github/actions/install-valkey-glide/action.yml
+++ b/.github/actions/install-valkey-glide/action.yml
@@ -46,6 +46,12 @@ runs:
         export PATH="$HOME/.cargo/bin:$PATH"
         curl -fsSL -o /tmp/valkey_glide.tgz \
           "https://github.com/valkey-io/valkey-glide-php/releases/download/v${{ inputs.version }}/valkey_glide-${{ inputs.version }}.tgz"
-        yes '' | sudo env HOME="$HOME" CARGO_HOME="$HOME/.cargo" PATH="$PATH" pecl install /tmp/valkey_glide.tgz || [[ $? -eq 141 ]]
+        set +o pipefail
+        yes '' | sudo env HOME="$HOME" CARGO_HOME="$HOME/.cargo" PATH="$PATH" pecl install /tmp/valkey_glide.tgz
+        pecl_exit=${PIPESTATUS[1]}
+        set -o pipefail
+        if [[ "${pecl_exit}" -ne 0 ]]; then
+          exit "${pecl_exit}"
+        fi
         echo "extension=valkey_glide.so" | sudo tee "$(php -r 'echo PHP_CONFIG_FILE_SCAN_DIR;')/99-valkey_glide.ini"
         rm -f /tmp/valkey_glide.tgz


### PR DESCRIPTION
## Summary
- Fix `install-valkey-glide` composite action failing CI after a successful `pecl install`
- `yes` exits with code 1 (not 141) when the pipe closes in GitHub Actions; the prior SIGPIPE guard did not catch it
- Disable `pipefail` for the `yes | pecl` pipe and fail only when `pecl` returns non-zero via `PIPESTATUS[1]`

## Test plan
- [ ] Merge and re-run common PR #14669 CI (phpstan + unit tests install valkey_glide via `@main`)

Made with [Cursor](https://cursor.com)