### PR TITLE
fix(php-common-bump): use --with-all-dependencies to cascade peer bumps

### DIFF
--- a/.github/workflows/php-common-bump.yaml
+++ b/.github/workflows/php-common-bump.yaml
@@ -69,11 +69,22 @@ jobs:
       - name: Update Common
         env:
           COMPOSER_AUTH: '{"http-basic": {"repo.packagist.com": {"username": "${{ secrets.packagist_username }}", "password": "${{secrets.packagist_password}}"}}}'
+        # --with-all-dependencies is required so composer can cascade the
+        # update to peer packages that common's composer.json newly pins to
+        # exact versions (e.g. common v12.247 pinned ebay-fulfillment-api-php-
+        # client to 1.0.3 exactly; without --with-all-dependencies composer
+        # refuses to update common alone because the peer would violate the
+        # constraint, and it exits cleanly with "Nothing to modify in lock
+        # file" — silently freezing every app whose lock had the older peer
+        # version). Root-cause investigation: 2026-08-10 fleet sweep showed
+        # 7 RT participants (radmin, catalog_api, listings-url-service,
+        # payments, returns-api, rp_api, webstore) stuck at v12.246.2 for
+        # 10 days.
         uses: nick-fields/retry@v4
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer update revolutionparts/common --prefer-dist --no-interaction --no-progress --optimize-autoloader --apcu-autoloader
+          command: composer update revolutionparts/common --with-all-dependencies --prefer-dist --no-interaction --no-progress --optimize-autoloader --apcu-autoloader
       - name: Commit Common Bump
         id: commit
         env:


### PR DESCRIPTION
## Summary

Fixes a fleet-wide silent freeze where nightly Common Update stopped bumping common on 7 RT participants for 10+ days without any visible failure.

## Root cause

Common v12.247 (shipped 2026-08-01) pinned a peer package to an exact version:

\`\`\`diff
-"revolutionparts/ebay-fulfillment-api-php-client": "^1.0",
+"revolutionparts/ebay-fulfillment-api-php-client": "1.0.3",
\`\`\`

Apps whose \`composer.lock\` had the older peer (1.0.1) couldn't update common alone via \`composer update revolutionparts/common\` because upgrading common would violate the new peer constraint. Composer's resolver correctly determines the update is unsatisfiable within the update whitelist and aborts with:

\`\`\`
Nothing to modify in lock file
\`\`\`

That's a **NO-OP success** from the workflow's perspective — no error, no non-zero exit, just silent freeze. Nightly runs kept reporting green while composer.lock sat at v12.246.2.

## Fleet sweep (2026-08-10)

Stuck at v12.246.2 with ebay-fulfillment-api-php-client=1.0.1:

- radmin
- catalog_api
- listings-url-service
- payments
- returns-api
- rp_api
- webstore

Avoided the freeze via a manual bump (had 1.0.3 in lock): internal_api, batch, dms-daemon, order-daemon.

## Fix

Pass \`--with-all-dependencies\` to the composer update:

\`\`\`diff
-composer update revolutionparts/common --prefer-dist ...
+composer update revolutionparts/common --with-all-dependencies --prefer-dist ...
\`\`\`

Standard composer idiom for "update this package plus whatever needs to move to accompany it." The alternative \`--with-dependencies\` only updates the target's direct requires; \`--with-all-dependencies\` also updates transitive requires, which is what we need when common newly-pins a peer.

## Rollout

1. Merge this to \`encodium/.github/main\` → all callers of \`php-common-bump.yaml@main\` pick it up on next invocation.
2. Companion per-repo unstick PRs are queued (7 draft PRs opening in parallel) so we don't have to wait 24h per repo for the fixed nightly to run.
3. Optional follow-up: emit a warning when \`composer update\` says "Nothing to modify" but the latest version on Packagist is newer than what's in the lock — would catch this class of silent freeze in the future.

## Test plan

- [ ] Merge, then re-run one stuck repo's Upgrade Common (workflow_dispatch). Expect: commit lands with both common and ebay-fulfillment-api-php-client bumped.
- [ ] Verify next scheduled nightly on stuck repos produces the same commit shape.