### PR TITLE
DEVEX: detect silent common freeze + fail loudly + alert Slack

### DIFF
--- a/.github/workflows/php-common-bump.yaml
+++ b/.github/workflows/php-common-bump.yaml
@@ -26,6 +26,14 @@ on:
         required: true
       packagist_password:
         required: true
+      slack_webhook_url:
+        # Optional. When set, a "silent-freeze detected" alert is posted to
+        # this webhook if the freeze-detection step trips. Freeze detection
+        # itself still runs (and fails the workflow loudly) regardless.
+        # Callers on RT participants should pass secrets.SLACK_WEBHOOK_URL
+        # so #releases gets the alert; callers without the secret still get
+        # the workflow-failure signal via GH email/mobile.
+        required: false
     outputs:
       commit_sha:
         description: "The commit SHA after bump (new commit if changes, otherwise triggering commit)"
@@ -74,6 +82,106 @@ jobs:
           timeout_minutes: 5
           max_attempts: 5
           command: composer update revolutionparts/common --prefer-dist --no-interaction --no-progress --optimize-autoloader --apcu-autoloader
+
+      # Detect the silent-freeze failure mode that hid a fleet-wide 10-day
+      # regression 2026-07-31 → 2026-08-10: common v12.247 pinned peer
+      # revolutionparts/ebay-fulfillment-api-php-client to exact 1.0.3;
+      # apps with 1.0.1 in their lock had `composer update revolutionparts/common`
+      # return "Nothing to modify in lock file" and exit 0. Nightly reported
+      # green every night while lock stayed pinned to v12.246.2.
+      #
+      # Distinguish real no-op (lock already at latest) from silent freeze
+      # (lock < Packagist because a peer constraint blocks the update alone)
+      # by comparing lock's common version against Packagist's latest. If
+      # Packagist has a newer version → the update was not truly a no-op,
+      # so surface it as a workflow failure + Slack alert.
+      - name: Detect silent freeze
+        id: freeze-check
+        env:
+          COMPOSER_AUTH: '{"http-basic": {"repo.packagist.com": {"username": "${{ secrets.packagist_username }}", "password": "${{secrets.packagist_password}}"}}}'
+        run: |
+          set -euo pipefail
+
+          # If the composer update produced lock changes, this is not a freeze.
+          if ! git diff-index --quiet HEAD -- composer.lock; then
+            echo "composer.lock changed - normal update path, no freeze possible."
+            echo "frozen=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          CURRENT=$(jq -r '.packages[] | select(.name == "revolutionparts/common") | .version' composer.lock)
+          # `composer show --latest` queries all configured repositories and
+          # reports both the installed version and the newest available. If
+          # they diverge, there's a newer version but composer refused to
+          # take it in the previous step. Use --format=json to parse safely.
+          SHOW_JSON=$(composer show revolutionparts/common --latest --format=json 2>/dev/null || echo '{}')
+          LATEST=$(echo "$SHOW_JSON" | jq -r '.latest // .version // ""')
+
+          echo "current=$CURRENT"
+          echo "latest=$LATEST"
+          echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
+          echo "latest=$LATEST" >> "$GITHUB_OUTPUT"
+
+          if [ -z "$LATEST" ] || [ "$CURRENT" = "$LATEST" ]; then
+            echo "::notice::composer.lock is at the latest available common ($CURRENT). Legitimate no-op."
+            echo "frozen=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # SILENT FREEZE. Emit diagnostic, then fail.
+          {
+            echo "## 🧊 Silent common freeze detected"
+            echo ""
+            echo "\`composer.lock\` is at \`revolutionparts/common@${CURRENT}\` but Packagist has \`${LATEST}\`."
+            echo "The previous \`composer update revolutionparts/common\` step reported \"Nothing to modify\" — but that was a resolver-abort, not a real no-op. Almost always caused by common raising a peer package's minimum version above what this repo's lock has."
+            echo ""
+            echo "### Diagnostic (\`composer why-not\`)"
+            echo ""
+            echo '```'
+            composer why-not "revolutionparts/common:${LATEST}" 2>&1 || true
+            echo '```'
+            echo ""
+            echo "### Recovery"
+            echo ""
+            echo "Run locally:"
+            echo '```'
+            echo "composer update revolutionparts/common -w"
+            echo '```'
+            echo "Commit the resulting \`composer.lock\` diff via PR."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "::error::composer.lock is at common@${CURRENT} but Packagist has ${LATEST}. Silent freeze — a peer constraint blocked the update. See job summary for the composer why-not diagnostic."
+          echo "frozen=true" >> "$GITHUB_OUTPUT"
+          exit 1
+
+      - name: Post freeze alert to Slack
+        # Only fires when freeze-check tripped AND the caller passed in a
+        # webhook. Callers without the webhook still get the workflow-failure
+        # signal via GH email / mobile notifications / red PR check.
+        if: failure() && steps.freeze-check.outputs.frozen == 'true' && env.SLACK_WEBHOOK_URL != ''
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_url }}
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          payload: |
+            {
+              "text": "🧊 common freeze on ${{ github.repository }} — locked at ${{ steps.freeze-check.outputs.current }}, Packagist has ${{ steps.freeze-check.outputs.latest }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "🧊 *Silent common freeze on `${{ github.repository }}`*\n\n`composer.lock` at *common@${{ steps.freeze-check.outputs.current }}* but Packagist has *${{ steps.freeze-check.outputs.latest }}*. `composer update revolutionparts/common` returned a false no-op — a peer constraint likely blocked the update.\n\nRecovery: `composer update revolutionparts/common -w` locally, commit the lock diff."
+                  },
+                  "accessory": {
+                    "type": "button",
+                    "text": { "type": "plain_text", "text": "View run" },
+                    "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                  }
+                }
+              ]
+            }
+
       - name: Commit Common Bump
         id: commit
         env:

--- a/.github/workflows/php-common-bump.yaml
+++ b/.github/workflows/php-common-bump.yaml
@@ -158,9 +158,15 @@ jobs:
         # Only fires when freeze-check tripped AND the caller passed in a
         # webhook. Callers without the webhook still get the workflow-failure
         # signal via GH email / mobile notifications / red PR check.
+        #
+        # SLACK_WEBHOOK_TYPE must be set to INCOMING_WEBHOOK; v1.24.0 defaults
+        # to Workflow Builder mode otherwise, silently no-op-ing our POST.
+        # Sibling workflow slack-deploy-notification.yaml already handles it
+        # the same way — this line mirrors that pattern.
         if: failure() && steps.freeze-check.outputs.frozen == 'true' && env.SLACK_WEBHOOK_URL != ''
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_url }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
         uses: slackapi/slack-github-action@v1.24.0
         with:
           payload: |

--- a/.github/workflows/php-common-bump.yaml
+++ b/.github/workflows/php-common-bump.yaml
@@ -115,7 +115,17 @@ jobs:
           # they diverge, there's a newer version but composer refused to
           # take it in the previous step. Use --format=json to parse safely.
           SHOW_JSON=$(composer show revolutionparts/common --latest --format=json 2>/dev/null || echo '{}')
-          LATEST=$(echo "$SHOW_JSON" | jq -r '.latest // .version // ""')
+          # printf, not echo. `echo "$SHOW_JSON" | jq` mangles JSON backslash
+          # escapes: common's composer.json ships a PSR-4 map like
+          # "RevolutionParts\\\\": "src/" (four backslashes → two literal
+          # in JSON → one literal in the parsed string), which echo
+          # collapses to single backslashes en route to jq's parser,
+          # invalidating the JSON. Verified locally 2026-08-10:
+          # `echo "$SHOW_JSON" | jq` → "parse error: Invalid numeric literal";
+          # `printf '%s' "$SHOW_JSON" | jq` → works. Without this fix the
+          # step would silently swallow every freeze detection (LATEST
+          # comes back empty → verdict "at latest" → freeze never surfaced).
+          LATEST=$(printf '%s' "$SHOW_JSON" | jq -r '.latest // .version // ""')
 
           echo "current=$CURRENT"
           echo "latest=$LATEST"


### PR DESCRIPTION
## Background

Fleet-wide 10-day silent regression 2026-07-31 → 2026-08-10:

Common v12.247 pinned \`revolutionparts/ebay-fulfillment-api-php-client\` to exact \`1.0.3\`. Apps whose composer.lock had \`1.0.1\` for that peer had \`composer update revolutionparts/common\` return **"Nothing to modify in lock file"** and exit 0, because composer's resolver correctly determined that upgrading common alone was unsatisfiable within the update whitelist. Nightly Common Update reported green every night while composer.lock stayed at v12.246.2 for 10 days on 7 repos.

The user-facing failure mode was invisible: no red X, no email, no Slack post. Only surfaced when a human happened to notice their app was on an old common.

## Fix

Add a \`Detect silent freeze\` step between \`Update Common\` and \`Commit Common Bump\`. When composer update produces no lock change, compare the lock's common version against Packagist's latest via \`composer show revolutionparts/common --latest --format=json\`:

| State | Action |
|---|---|
| lock changed | normal update path — commit + push |
| lock unchanged AND at latest | legitimate no-op → exit 0 |
| lock unchanged AND lock < latest | **SILENT FREEZE** — dump \`composer why-not\` to job summary, exit 1, fire Slack (if configured) |

Add optional \`slack_webhook_url\` secret. When set, failures also post to Slack. When not set, only the GH workflow failure signal fires (email, mobile, PR check).

## Design vs the closed alternative

Considered making \`composer update\` more aggressive with \`--with-all-dependencies\` in encodium/.github#160 (now closed). Rejected because it papers over the real issue: upstream constraint choices that break the fleet should surface as failures we can **respond to**, not be silently worked around. The right forcing function is the workflow failure + Slack alert.

## Coverage

Applies to every caller of \`php-common-bump.yaml@main\` — every RT participant's Nightly Common Update + Upgrade Common workflows pick it up automatically the next time they run.

## Callers that pass \`slack_webhook_url\`

None currently. For those to get the Slack alert, each caller needs to add \`slack_webhook_url: \${{ secrets.SLACK_WEBHOOK_URL }}\` under \`secrets:\` in their Upgrade Common / Nightly Common Update workflow. That's a small opt-in sweep — happy to draft it as a follow-up PR set, but not required for this change to be useful (workflow failures still surface without Slack).

## Companion PRs

- **encodium/common** — unpin \`ebay-fulfillment-api-php-client\` from exact \`1.0.3\` back to \`^1.0.3\` (root-cause fix for the specific freeze that motivated this PR)
- **7 per-repo unstick PRs** (radmin / catalog_api / listings-url-service / payments / returns-api / rp_api / webstore) — manually push each stuck lock forward to peer 1.0.3 + common v12.255.3

## Test plan

- [ ] Merge
- [ ] Confirm next Nightly Common Update on a repo already at latest common: freeze-check step logs "at latest", commit step logs "No changes to commit", workflow green (same as before)
- [ ] Confirm next Nightly Common Update on a repo with a lock update available: normal commit + push path (same as before)
- [ ] Once the seven unstick PRs merge, verify no stuck repos remain. Then, if a future common constraint change re-freezes any repo, expect the alert (red X + Slack)