### PR TITLE
[PLAT-5173] Add GOMEMLIMIT Helm snippet and chart lint warning

### DIFF
--- a/.github/actions/helm-chart-lint/action.yml
+++ b/.github/actions/helm-chart-lint/action.yml
@@ -31,6 +31,7 @@ inputs:
       budget
       daemons
       envConfigMap
+      go
       image
       imagePullSecrets
       ingress

--- a/.github/actions/helm-chart-lint/scripts/lint.sh
+++ b/.github/actions/helm-chart-lint/scripts/lint.sh
@@ -218,6 +218,22 @@ fi
 
 end
 
+# ---------------------------------------------------------------------------
+# Rule 8 — Go services: warn when rendered chart lacks GOMEMLIMIT (PLAT-5173)
+# ---------------------------------------------------------------------------
+info "Rule 8: Go services should set GOMEMLIMIT"
+
+REPO_ROOT="$(cd "$CHART_PATH/.." && pwd)"
+if [[ -f "$REPO_ROOT/go.mod" ]]; then
+    if ! rendered="$(helm template "$CHART_PATH" 2>/tmp/helm-gomemlimit.err)"; then
+        echo "::warning::Rule 8 skipped: helm template failed for GOMEMLIMIT check ($(cat /tmp/helm-gomemlimit.err | tr '\n' ' '))"
+    elif ! echo "$rendered" | grep -qE 'name:[[:space:]]+GOMEMLIMIT'; then
+        echo "::warning::$CHART_PATH: go.mod present but rendered manifests lack GOMEMLIMIT env. See encodium/.github/helm/snippets/go-gomemlimit.tpl (PLAT-5173)."
+    fi
+fi
+
+end
+
 if [[ "$FAILED" -ne 0 ]]; then
     echo "::error::helm-chart-lint: one or more rules failed. See annotations above." >&2
     exit 1

--- a/.github/actions/helm-chart-lint/scripts/lint.sh
+++ b/.github/actions/helm-chart-lint/scripts/lint.sh
@@ -14,7 +14,7 @@
 set -euo pipefail
 
 CHART_PATH="${CHART_PATH:-./deployments}"
-RESERVED_KEYS="${RESERVED_KEYS:-app budget daemons envConfigMap image imagePullSecrets ingress keda replicas resources serviceAccount serviceAccountName vault}"
+RESERVED_KEYS="${RESERVED_KEYS:-app budget daemons envConfigMap go image imagePullSecrets ingress keda replicas resources serviceAccount serviceAccountName vault}"
 
 # `app` is always implicitly reserved (Rule 5 requires it; the action.yml input
 # documents the per-chart list as "in addition to `app`"). Prepend defensively

--- a/.github/workflows/test-helm-actions.yaml
+++ b/.github/workflows/test-helm-actions.yaml
@@ -40,7 +40,7 @@ jobs:
         env:
           CHART_PATH: .github/actions/helm-chart-lint/tests/fixtures/bad-chart
           RESERVED_KEYS: >-
-            app budget daemons envConfigMap image imagePullSecrets ingress keda
+            app budget daemons envConfigMap go image imagePullSecrets ingress keda
             replicas resources serviceAccount serviceAccountName vault
         run: |
           set +e

--- a/helm/snippets/README.md
+++ b/helm/snippets/README.md
@@ -18,7 +18,7 @@ Copy the `app.goMemoryLimit` define from [go-gomemlimit.tpl](./go-gomemlimit.tpl
 
 ### 2. `deployments/values.yaml`
 
-Add (or merge) under top-level chart-control keys:
+Add (or merge) under top-level chart-control keys (`go` is reserved by `helm-chart-lint` Rule 6):
 
 ```yaml
 go:

--- a/helm/snippets/README.md
+++ b/helm/snippets/README.md
@@ -1,0 +1,76 @@
+# Helm snippets — Go memory limits (GOMEMLIMIT)
+
+Platform standard for aligning the Go runtime with Kubernetes cgroup memory limits ([PLAT-5173](https://revolutionparts.atlassian.net/browse/PLAT-5173)).
+
+## When to use
+
+Any **Go service** deployed to EKS with `resources.limits.memory` on the application container. Go auto-detects cgroup CPU limits but **not** memory; without `GOMEMLIMIT`, the kernel may OOM-kill the process instead of the GC throttling heap growth.
+
+**In scope (active services):** `products-api`, `shipments-api`.
+
+**Out of scope:** Deprecated APIs planned for archival (`prices-api`, `suppliers-api`). Argo WorkflowTemplates in `encodium/workflows` use a separate chart — track as a follow-up under [PLAT-5128](https://revolutionparts.atlassian.net/browse/PLAT-5128).
+
+## Install
+
+### 1. `deployments/templates/_helpers.tpl`
+
+Copy the `app.goMemoryLimit` define from [go-gomemlimit.tpl](./go-gomemlimit.tpl) into your chart's `_helpers.tpl`.
+
+### 2. `deployments/values.yaml`
+
+Add (or merge) under top-level chart-control keys:
+
+```yaml
+go:
+  memoryLimitRatio: 0.85
+resources:
+  limits:
+    memory: "256Mi"   # single source of truth for cgroup + derived GOMEMLIMIT
+```
+
+`memoryLimitRatio` defaults to `0.85` (85% of limit). Epic guidance is 80–90%; leave ~10–20% headroom for non-heap memory (DB/Redis client buffers, stacks, OpenTelemetry).
+
+### 3. `deployments/templates/deployment.yaml`
+
+On the **go** application container `env` block:
+
+```yaml
+            - name: GOMEMLIMIT
+              value: {{ include "app.goMemoryLimit" . | quote }}
+```
+
+## Verification
+
+```bash
+# Happy path — expect derived value (e.g. 256Mi limit → 217MiB)
+helm template <release> deployments/ -f deployments/values.yaml --set image.tag=test | rg -A1 'name: GOMEMLIMIT'
+
+# Custom limit — 512Mi → 435MiB
+helm template <release> deployments/ -f deployments/values.yaml \
+  --set image.tag=test --set resources.limits.memory=512Mi | rg -A1 'name: GOMEMLIMIT'
+
+# Negative — must fail render
+helm template <release> deployments/ -f deployments/values.yaml \
+  --set image.tag=test --set resources.limits.memory=null
+```
+
+Post-deploy:
+
+```bash
+kubectl exec -n api deploy/<service> -- printenv GOMEMLIMIT
+```
+
+Datadog (48h soak): `source:oom_kill service:<service-name>`
+
+## Constraints
+
+- `resources.limits.memory` **must** use a `Mi` suffix. `Gi` limits are not supported by this helper; extend locally if needed.
+- Do not hardcode `GOMEMLIMIT` — derive from the container limit so limit changes stay in sync.
+- `GOMEMLIMIT` aligns runtime GC with the cgroup ceiling; it does **not** replace right-sizing `resources.requests` from Datadog RSS baselines.
+
+## Reference implementations
+
+- [encodium/products-api](https://github.com/encodium/products-api) — [PLAT-5155](https://revolutionparts.atlassian.net/browse/PLAT-5155)
+- [encodium/shipments-api](https://github.com/encodium/shipments-api) — [PLAT-5164](https://revolutionparts.atlassian.net/browse/PLAT-5164)
+
+Platform doc: dotfiles `docs/kubernetes/go-memory-limits.md` (served via rp-context).

--- a/helm/snippets/go-gomemlimit.tpl
+++ b/helm/snippets/go-gomemlimit.tpl
@@ -9,7 +9,8 @@
 */}}
 {{- define "app.goMemoryLimit" -}}
 {{- $memoryLimit := required "resources.limits.memory must be set" .Values.resources.limits.memory | toString -}}
-{{- $ratio := .Values.go.memoryLimitRatio | default 0.85 | float64 -}}
+{{- $go := .Values.go | default dict -}}
+{{- $ratio := $go.memoryLimitRatio | default 0.85 | float64 -}}
 {{- if not (hasSuffix "Mi" $memoryLimit) -}}
 {{- fail (printf "resources.limits.memory must use Mi suffix for GOMEMLIMIT calculation, got %q" $memoryLimit) -}}
 {{- end -}}

--- a/helm/snippets/go-gomemlimit.tpl
+++ b/helm/snippets/go-gomemlimit.tpl
@@ -1,0 +1,18 @@
+{{/*
+  Canonical GOMEMLIMIT helper for Go services on Kubernetes (PLAT-5173).
+
+  Copy this block into deployments/templates/_helpers.tpl in Go API repos.
+  See helm/snippets/README.md for values.yaml, deployment.yaml, and verification steps.
+
+  Derives GOMEMLIMIT from resources.limits.memory and go.memoryLimitRatio (default 0.85).
+  resources.limits.memory must use a Mi suffix (e.g. 256Mi, 3000Mi).
+*/}}
+{{- define "app.goMemoryLimit" -}}
+{{- $memoryLimit := required "resources.limits.memory must be set" .Values.resources.limits.memory | toString -}}
+{{- $ratio := .Values.go.memoryLimitRatio | default 0.85 | float64 -}}
+{{- if not (hasSuffix "Mi" $memoryLimit) -}}
+{{- fail (printf "resources.limits.memory must use Mi suffix for GOMEMLIMIT calculation, got %q" $memoryLimit) -}}
+{{- end -}}
+{{- $memoryMi := trimSuffix "Mi" $memoryLimit | int -}}
+{{- printf "%dMiB" (int (mulf $ratio (float64 $memoryMi))) -}}
+{{- end -}}


### PR DESCRIPTION
## Description

Platform tooling for [PLAT-5173](https://revolutionparts.atlassian.net/browse/PLAT-5173): add a canonical Helm helper and install guide for deriving `GOMEMLIMIT` from `resources.limits.memory`, and extend `helm-chart-lint` with Rule 8 to warn when a Go repo (`go.mod` present) renders manifests without `GOMEMLIMIT`.

- **`helm/snippets/go-gomemlimit.tpl`** — `app.goMemoryLimit` helper: `resources.limits.memory` × `go.memoryLimitRatio` (default `0.85`), `Mi` suffix required, fails render on missing/invalid limit
- **`helm/snippets/README.md`** — install steps for `_helpers.tpl`, `values.yaml`, and `deployment.yaml`, plus verification commands and scope (active: `products-api`, `shipments-api`)
- **`.github/actions/helm-chart-lint/scripts/lint.sh`** — Rule 8 emits a `::warning::` when `helm template` output lacks `GOMEMLIMIT` (non-blocking; skips if template render fails)

**Jira Issue:** https://revolutionparts.atlassian.net/browse/PLAT-5173

## Background

- Platform audit under [PLAT-5128](https://revolutionparts.atlassian.net/browse/PLAT-5128) found no Go services with `GOMEMLIMIT` configured; Go auto-detects cgroup CPU limits but not memory, leading to kernel OOM kills (confirmed on products-api — [PLAT-5155](https://revolutionparts.atlassian.net/browse/PLAT-5155)).
- Per-service rollouts already landed in `products-api` ([PLAT-5155](https://revolutionparts.atlassian.net/browse/PLAT-5155)) and `shipments-api` ([PLAT-5164](https://revolutionparts.atlassian.net/browse/PLAT-5164)); this PR centralizes the reusable pattern in `encodium/.github` so future Go APIs adopt the same helper.
- Deprecated APIs (`prices-api`, `suppliers-api`) and Argo WorkflowTemplates in `encodium/workflows` are out of scope here; workflows tracked under [PLAT-5128](https://revolutionparts.atlassian.net/browse/PLAT-5128).

## Related PRs

- [encodium/products-api](https://github.com/encodium/products-api) — [PLAT-5155](https://revolutionparts.atlassian.net/browse/PLAT-5155)
- [encodium/shipments-api](https://github.com/encodium/shipments-api) — [PLAT-5164](https://revolutionparts.atlassian.net/browse/PLAT-5164)

## Testing Information

### Pre-merge

From a Go API repo that uses `helm-chart-lint` (e.g. `products-api`):

```bash
# Rule 8 — repo with go.mod + GOMEMLIMIT should pass (no Rule 8 warning)
# Run the chart lint action locally or via CI on a branch with the snippet applied

# Snippet happy path — 256Mi limit → 217MiB
helm template <release> deployments/ -f deployments/values.yaml --set image.tag=test | rg -A1 'name: GOMEMLIMIT'

# Custom limit — 512Mi → 435MiB
helm template <release> deployments/ -f deployments/values.yaml \
  --set image.tag=test --set resources.limits.memory=512Mi | rg -A1 'name: GOMEMLIMIT'

# Negative — must fail render
helm template <release> deployments/ -f deployments/values.yaml \
  --set image.tag=test --set resources.limits.memory=null
  
```
```  
  Expected happy-path output
            - name: GOMEMLIMIT
              value: "217MiB"
```

### Expected errors
- resources.limits.memory must be set
- resources.limits.memory must use Mi suffix for GOMEMLIMIT calculation, got "256Gi"

### Pre-merge checklist
- [x] helm/snippets/go-gomemlimit.tpl renders expected GOMEMLIMIT for 256Mi and 512Mi limits
- [ ]  Template fails when resources.limits.memory is null or not Mi suffix
- [ ]  Rule 8 warns on a Go repo chart missing GOMEMLIMIT; no warning when snippet is applied
- [ ]  Rule 8 skips gracefully when helm template fails (warning only, does not fail lint)

### Post-deploy follow-up
- No runtime deploy from this repo. After consuming repos merge and deploy:

```
kubectl exec -n api deploy/<service> -- printenv GOMEMLIMIT
```

Datadog (48h soak on rolled-out services): source:oom_kill service:<service-name> — confirm no new OOM kills attributable to missing memory limit.

[PLAT-5173]: https://revolutionparts.atlassian.net/browse/PLAT-5173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PLAT-5128]: https://revolutionparts.atlassian.net/browse/PLAT-5128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ