### PR TITLE
fix(php-common-bump): change alert wording to avoid "freeze" collision

### DIFF
--- a/.github/workflows/php-common-bump.yaml
+++ b/.github/workflows/php-common-bump.yaml
@@ -138,17 +138,22 @@ jobs:
             exit 0
           fi
 
-          # SILENT FREEZE. Emit diagnostic, then fail.
+          # AUTOMATIC UPDATE BLOCKED. Emit diagnostic, then fail.
+          #
+          # Wording chosen to avoid collision with the org's existing "code
+          # freeze" convention — this alert is about composer failing to
+          # cascade a common update because peer constraints in common moved.
+          # It's an automated-update problem, not a code-freeze.
           {
-            echo "## 🧊 Silent common freeze detected"
+            echo "## ⚠️ Common could not be automatically updated"
             echo ""
             echo "\`composer.lock\` is at \`revolutionparts/common@${CURRENT}\` but Packagist has \`${LATEST}\`."
-            echo "The previous \`composer update revolutionparts/common\` step reported \"Nothing to modify\" — but that was a resolver-abort, not a real no-op. Almost always caused by common raising a peer package's minimum version above what this repo's lock has."
+            echo "The previous \`composer update revolutionparts/common\` step reported \"Nothing to modify\" — but that was a resolver-abort, not a real no-op. Almost always caused by common raising one or more peer packages' minimum versions above what this repo's lock has (composer's default \`update <pkg>\` doesn't cascade to peers)."
             echo ""
             echo "### Diagnostic (\`composer why-not\`)"
             echo ""
             echo '```'
-            composer why-not "revolutionparts/common:${LATEST}" 2>&1 || true
+            composer why-not revolutionparts/common "${LATEST}" 2>&1 || true
             echo '```'
             echo ""
             echo "### Recovery"
@@ -160,7 +165,7 @@ jobs:
             echo "Commit the resulting \`composer.lock\` diff via PR."
           } >> "$GITHUB_STEP_SUMMARY"
 
-          echo "::error::composer.lock is at common@${CURRENT} but Packagist has ${LATEST}. Silent freeze — a peer constraint blocked the update. See job summary for the composer why-not diagnostic."
+          echo "::error::composer.lock is at common@${CURRENT} but Packagist has ${LATEST}. Common could not be automatically updated — peer constraints in common blocked the update. See job summary for the composer why-not diagnostic."
           echo "frozen=true" >> "$GITHUB_OUTPUT"
           exit 1
 
@@ -181,13 +186,13 @@ jobs:
         with:
           payload: |
             {
-              "text": "🧊 common freeze on ${{ github.repository }} — locked at ${{ steps.freeze-check.outputs.current }}, Packagist has ${{ steps.freeze-check.outputs.latest }}",
+              "text": "⚠️ Common could not be automatically updated on ${{ github.repository }} — lock at ${{ steps.freeze-check.outputs.current }}, Packagist has ${{ steps.freeze-check.outputs.latest }}",
               "blocks": [
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "🧊 *Silent common freeze on `${{ github.repository }}`*\n\n`composer.lock` at *common@${{ steps.freeze-check.outputs.current }}* but Packagist has *${{ steps.freeze-check.outputs.latest }}*. `composer update revolutionparts/common` returned a false no-op — a peer constraint likely blocked the update.\n\nRecovery: `composer update revolutionparts/common -w` locally, commit the lock diff."
+                    "text": "⚠️ *Common could not be automatically updated on `${{ github.repository }}`*\n\n`composer.lock` is at *common@${{ steps.freeze-check.outputs.current }}* but Packagist has *${{ steps.freeze-check.outputs.latest }}*. `composer update revolutionparts/common` reported no changes — one or more peer constraints in common likely require lockfile bumps that `composer update` alone doesn't cascade.\n\n*Recovery:* run `composer update revolutionparts/common -w` locally and commit the lock diff."
                   },
                   "accessory": {
                     "type": "button",


### PR DESCRIPTION
**Ticket:** [DEVEX-1767](https://revolutionparts.atlassian.net/browse/DEVEX-1767)

## Summary

Team feedback in #release: the 🧊 emoji and \"silent common freeze\" phrasing collide with the org's existing \"code freeze\" convention. This alert is about an automated dep update failing to cascade — nothing to do with code freezes.

## Changes

- Emoji: 🧊 → ⚠️
- Header: \"Silent common freeze\" → \"Common could not be automatically updated\"
- Body: rewritten to say \"reported no changes\" instead of \"returned a false no-op\", and to acknowledge that **one or more peer constraints** in common typically drive this (accurate given today's diagnostic — see below — where common v12.256.2 raised the floor on five peer packages simultaneously)
- Applies to both the job-summary diagnostic and the Slack post

## Diagnostic run (from a real firing today)

Ran `composer why-not revolutionparts/common v12.256.2` on catalog_api's stuck lock:

\`\`\`
revolutionparts/common v12.256.2 requires  auth0/auth0-php (^8.17)
__root__               dev-main  does not require auth0/auth0-php (but 8.15.0 is installed)
revolutionparts/common v12.256.2 requires  encodium/shipments-api-php-client (^2.0.6)
__root__               dev-main  does not require encodium/shipments-api-php-client (but v2.0.2 is installed)
revolutionparts/common v12.256.2 requires  firebase/php-jwt (^7)
__root__               dev-main  does not require firebase/php-jwt (but v3.0.0 is installed)
revolutionparts/common v12.256.2 requires  jlevers/selling-partner-api (^7.4.6)
__root__               dev-main  does not require jlevers/selling-partner-api (but v7.4.1 is installed)
revolutionparts/common v12.256.2 requires  revolutionparts/rocketshipit (^1.2.1)
__root__               dev-main  does not require revolutionparts/rocketshipit (but v1.2.0 is installed)
\`\`\`

Five separate peer bumps in common between v12.255.3 and v12.256.2 — none exact-pinned, all standard caret ranges. The freeze is composer's designed behavior around `update <pkg>` not cascading to peers; not a bug in common's constraint discipline. So the alert phrasing shouldn't imply blame, just describe the situation and point at the recovery.

## Ride-along bug fix

The `composer why-not` command in the job summary had wrong syntax (`composer why-not \"pkg:version\"`) — composer wants two separate positional args. Every diagnostic since the freeze-detect step landed silently emitted \"Not enough arguments (missing: 'version')\" instead of the real why-not tree. Fixed to `composer why-not revolutionparts/common \"\$LATEST\"`.

## Test plan

- [ ] Merge
- [ ] Next Nightly Common Update tonight (2 UTC) fires against still-stuck repos → expect single ⚠️ Slack post per stuck repo with the new wording + a real composer why-not diagnostic in the job summary

[DEVEX-1767]: https://revolutionparts.atlassian.net/browse/DEVEX-1767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ