### PR TITLE
fix(php-common-bump): recommend -W not -w for freeze recovery

### DIFF
--- a/.github/workflows/php-common-bump.yaml
+++ b/.github/workflows/php-common-bump.yaml
@@ -160,7 +160,7 @@ jobs:
             echo ""
             echo "Run locally:"
             echo '```'
-            echo "composer update revolutionparts/common -w"
+            echo "composer update revolutionparts/common -W"
             echo '```'
             echo "Commit the resulting \`composer.lock\` diff via PR."
           } >> "$GITHUB_STEP_SUMMARY"
@@ -192,7 +192,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "⚠️ *Common could not be automatically updated on `${{ github.repository }}`*\n\n`composer.lock` is at *common@${{ steps.freeze-check.outputs.current }}* but Packagist has *${{ steps.freeze-check.outputs.latest }}*. `composer update revolutionparts/common` reported no changes — one or more peer constraints in common likely require lockfile bumps that `composer update` alone doesn't cascade.\n\n*Recovery:* run `composer update revolutionparts/common -w` locally and commit the lock diff."
+                    "text": "⚠️ *Common could not be automatically updated on `${{ github.repository }}`*\n\n`composer.lock` is at *common@${{ steps.freeze-check.outputs.current }}* but Packagist has *${{ steps.freeze-check.outputs.latest }}*. `composer update revolutionparts/common` reported no changes — one or more peer constraints in common likely require lockfile bumps that `composer update` alone doesn't cascade.\n\n*Recovery:* run `composer update revolutionparts/common -W` locally and commit the lock diff."
                   },
                   "accessory": {
                     "type": "button",


### PR DESCRIPTION
**Ticket:** [DEVEX-1767](https://revolutionparts.atlassian.net/browse/DEVEX-1767)

## Summary

The recovery command in our freeze alert (\`composer update revolutionparts/common -w\`) doesn't work in all cases. Discovered on webstore's failed [run 31549535923](https://github.com/encodium/webstore/actions/runs/31549535923).

## The gap

\`-w\` (\`--with-dependencies\`) cascades to peers **but excludes packages the repo has as root requires** (i.e., in its own \`composer.json\` require block). Any freeze where common has raised the floor on such a package produces a silent no-op — same freeze persists after "recovery."

## Concrete case

- **webstore's composer.json** requires \`encodium/shipments-api-php-client: "^2.0"\` (root require).
- **common v12.257** requires \`^2.0.6\` for that peer.
- **`composer update revolutionparts/common -w`** on webstore → refuses to touch shipments-api-php-client (root exclusion) → can't satisfy common's constraint → aborts silently → 0-line diff.
- **`composer update revolutionparts/common -W`** on the same repo → 96/273-line diff, common bumped v12.255.3 → v12.257.3 ✓

## Fix

Recommend \`-W\` (\`--with-all-dependencies\`) instead of \`-w\` in both the Slack post and the job-summary diagnostic.

- Slightly more surprising for the developer — a root require they explicitly declared can now move.
- But it's the composer idiom that actually cascades everything needed to satisfy common's constraint.

## Retrospective note

Yesterday's fleet unstick round used \`-w\` successfully because the peer that mattered then (\`ebay-fulfillment-api-php-client\`) was never a root require anywhere — it was transitive via common. Today's freeze pattern (\`shipments-api-php-client\`, which IS a root require on webstore and other repos) exposed the gap.

## Test plan

- [ ] Merge
- [ ] Next Nightly Common Update tonight on a still-stuck repo → alert body shows the \`-W\` command

[DEVEX-1767]: https://revolutionparts.atlassian.net/browse/DEVEX-1767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ