### PR TITLE
fix(semantic-release): bump the major for breaking changes

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -21,17 +21,129 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          # fetch-depth: 0 brings the tags, which the detection step below needs to resolve
+          # `refs/tags/<previous_tag>`. Do not make this shallow.
           fetch-depth: 0
+
+      # Learn the previous tag before tagging. Needed separately because the action leaves
+      # `previous_version` undefined whenever `custom_tag` is set, which the breaking-change
+      # path below does.
+      - name: Compute next version (dry run)
+        id: dry
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          fetch_all_tags: true
+          dry_run: true
+
+      # github-tag-action@v6.2 calls @semantic-release/commit-analyzer@8 as a library and
+      # passes it no preset, so it parses with `angular`, whose headerPattern predates the
+      # Conventional Commits `!` marker and which defines no breakingHeaderPattern:
+      #     /^(\w*)(?:\((.*)\))?: (.*)$/
+      # `feat(scope)!: ...` fails that regex outright, so the type is discarded along with the
+      # breaking signal, no release rule fires, and the action falls back to
+      # `default_bump: patch`. Its changelog step separately uses the `conventionalcommits`
+      # preset, which *does* understand `!`. That split brain shipped
+      # encodium/vehicle-service v1.1.1: a patch whose own release notes were headed
+      # "BREAKING CHANGES". Upstream #80 and #208 are open and v6.2 (2024-03) is the last
+      # release, so detect it here.
+      #
+      # NOTE: the subject check assumes conventional-commit PR titles, since the squash
+      # subject comes from the PR title. The convention documented in git-commit-lint.yaml is
+      # `<TICKET-ID>: <description>`, under which a `!` marker could never appear. Repos using
+      # that style rely on the footer check instead.
+      - name: Detect breaking changes since previous tag
+        id: breaking
+        env:
+          PREV_TAG: ${{ steps.dry.outputs.previous_tag }}
+        run: |
+          set -euo pipefail
+          # getLatestTag() returns a synthetic `v0.0.0` when the repo has no tags. Scanning all
+          # history in that case would force 1.0.0 off some ancient `!` commit, so leave a
+          # repo's first release on the normal path.
+          if ! git rev-parse -q --verify "refs/tags/${PREV_TAG}" >/dev/null; then
+            echo "No previous tag (${PREV_TAG}); skipping breaking-change detection."
+            echo "breaking=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          subjects=$(git log --format='%s' "${PREV_TAG}..HEAD")
+          bodies=$(git log --format='%B' "${PREV_TAG}..HEAD")
+          breaking=false
+          # Here-strings, NOT pipes. `git log ... | grep -q` lets grep close the pipe on its
+          # first match; git log then dies with SIGPIPE (141); `pipefail` promotes that to the
+          # pipeline's status and the `if` takes the FALSE branch. That fails open -- the exact
+          # class of silent under-detection this step exists to prevent.
+          if grep -qE '^[a-zA-Z]+(\([^)]*\))?!:' <<< "$subjects"; then breaking=true; fi
+          # conventional-commits-parser accepts `BREAKING CHANGE` followed by `:` or whitespace,
+          # and the hyphenated spelling. Match the parser, not a stricter subset.
+          if grep -qE '^BREAKING[ -]CHANGE([:[:space:]])' <<< "$bodies"; then breaking=true; fi
+          echo "Breaking change detected: ${breaking}"
+          echo "breaking=${breaking}" >> "$GITHUB_OUTPUT"
+
+      - name: Compute forced major
+        id: major
+        if: steps.breaking.outputs.breaking == 'true'
+        env:
+          PREV: ${{ steps.dry.outputs.previous_version }}
+        run: |
+          set -euo pipefail
+          # Refuse to guess. `set -u` does not help: PREV is *set* to empty by `env:`, and
+          # `$(( + 1 ))` is valid bash evaluating to 1 -- so an empty PREV would silently retag
+          # a v12.x package as v1.0.0. The action's custom_tag path performs no valid() or
+          # monotonicity check, unlike its normal path, so nothing downstream would catch it.
+          if ! [[ "$PREV" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::previous_version '$PREV' is not a plain release semver; refusing to force a major." >&2
+            exit 1
+          fi
+          # Mirrors semver.inc(version, 'major'), including 0.x -> 1.0.0.
+          echo "custom_tag=$(( ${PREV%%.*} + 1 )).0.0" >> "$GITHUB_OUTPUT"
+
+      # createTag() runs *inside* github-tag-action, and Private Packagist versions packages
+      # from git tags rather than GitHub Releases -- so any check placed after the tag step is
+      # a post-mortem, not a gate. This is a workflow expression precisely so it cannot fail
+      # open the way `[ "$a" -le "$b" ]` does on a non-integer operand (returns 2, and as an
+      # `if` condition does not trip `set -e`).
+      - name: Gate - a detected breaking change must carry a forced major
+        if: steps.breaking.outputs.breaking == 'true' && steps.major.outputs.custom_tag == ''
+        run: |
+          echo "::error::Breaking change detected but no forced major was computed; refusing to tag." >&2
+          exit 1
+
       - name: Bump version and push tag
         id: tag_version
         uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           fetch_all_tags: true
+          # Empty on every non-breaking push, which falls through to the action's normal bump
+          # path (core.getInput returns '' for both unset and empty, and `if (customTag)` is
+          # falsy). Note this sets release_type to `custom` rather than `major` when forced --
+          # nothing here consumes it, but build-php-laravel.yaml and build-php-v1.yaml do read
+          # this action's outputs, so audit them before copying this pattern across.
+          custom_tag: ${{ steps.major.outputs.custom_tag }}
+
+      - name: Verify the tag that was created
+        if: steps.breaking.outputs.breaking == 'true'
+        env:
+          EXPECTED: ${{ steps.major.outputs.custom_tag }}
+          ACTUAL: ${{ steps.tag_version.outputs.new_version }}
+        run: |
+          set -euo pipefail
+          # String equality with explicit emptiness checks. Also catches the action's
+          # early-return-when-tag-already-exists path, where new_version is set but this run
+          # created nothing.
+          if [ -z "$EXPECTED" ] || [ -z "$ACTUAL" ] || [ "$EXPECTED" != "$ACTUAL" ]; then
+            echo "::error::expected v${EXPECTED:-<empty>}, action produced v${ACTUAL:-<empty>}." >&2
+            exit 1
+          fi
+
       - name: Create a GitHub release
         uses: ncipollo/release-action@v1
         with:
           tag: ${{ steps.tag_version.outputs.new_tag }}
           name: ${{ steps.tag_version.outputs.new_tag }}
           body: ${{ steps.tag_version.outputs.changelog }}
-          prerelease: ${{ steps.tag_version.outputs.is_prerelease }}
+          # github-tag-action has no `is_prerelease` output -- its outputs are new_tag,
+          # new_version, previous_tag, previous_version, release_type and changelog. This read
+          # the empty string on every run, and the workflow_call input above was never used.
+          prerelease: ${{ inputs.is_prerelease }}


### PR DESCRIPTION
## Summary

This workflow versions the 47 split package repos under `encodium/common`'s `src/`, and it has **never produced a major bump**. `encodium/vehicle-service` released a breaking change as [v1.1.1](https://github.com/encodium/vehicle-service/releases/tag/v1.1.1) — a patch — whose own release notes are headed `### ⚠ BREAKING CHANGES`.

`mathieudutour/github-tag-action@v6.2` calls `@semantic-release/commit-analyzer@8` as a library and passes it **no preset**, so it parses with `angular`, whose `headerPattern` predates the Conventional Commits `!` marker and which defines no `breakingHeaderPattern`:

```
/^(\w*)(?:\((.*)\))?: (.*)$/
```

`feat(scope)!: …` fails that regex outright, so the `type` is discarded along with the breaking signal, no release rule fires, and the action falls back to `default_bump: patch`. The action's *changelog* step separately uses the `conventionalcommits` preset, which **does** understand `!` — which is why the notes and the number disagree.

Measured directly against `@semantic-release/commit-analyzer@8.0.1` with the real commit message:

| commit message | `analyzeCommits` result |
|---|---|
| `feat(vehicle)!: …` subject only (**what shipped**) | `null` → no release → `default_bump: patch` |
| `feat(vehicle)!: …` + `BREAKING CHANGE:` footer | **`major`** |
| `feat(vehicle): …` + `BREAKING CHANGE:` footer | **`major`** |
| `feat(vehicle): add thing` | `minor` |

From the failing run ([31816171603](https://github.com/encodium/vehicle-service/actions/runs/31816171603)):

```
Analyzing commit: feat(vehicle)!: resolve products-api catalog IDs for licensed makes (#14799)
The commit should not trigger a release
Analysis of 1 commits complete: no release
New version is 1.1.1.
```

Not even the `feat` minor survived, which pins this on the header regex rather than on breaking-change detection alone.

Upstream [#80](https://github.com/mathieudutour/github-tag-action/issues/80) and [#208](https://github.com/mathieudutour/github-tag-action/issues/208) are both open and v6.2 (2024-03) is the last release, so this is worked around here rather than waited on.

**Known damage:** `vehicle-service` v1.1.1 and v0.0.4, `value-object` v1.11.2 and v1.11.3. No split repo has any tag with major ≥ 2.

## Changes

- A detection step covering both the `!` marker and the `BREAKING CHANGE:` / `BREAKING-CHANGE:` footer, over `previous_tag..HEAD`.
- A forced major fed through the action's existing `custom_tag` input.
- A gate, before the tag step, that refuses to tag if a breaking change was detected but no major was computed.
- A post-tag check that the created tag is the one we asked for.
- Fixes a dead wire: `prerelease` read `steps.tag_version.outputs.is_prerelease`, which this action does not emit, so it was always `''` while the `is_prerelease` workflow input went unread. It now reads the input.

**Existing behaviour is unchanged on non-breaking pushes.** `custom_tag` is empty then, and `core.getInput` returns `''` for both unset and empty while `if (customTag)` is falsy — so it falls straight through to the normal bump path, `default_bump: patch` included.

### Why several lines look over-careful

Each one is a failure mode that was reproduced, not hypothesised:

- **Here-strings, not pipes.** `git log … | grep -q` lets `grep` close the pipe on its first match; `git log` dies with SIGPIPE (141); `pipefail` promotes that to the pipeline status and the `if` takes the **false** branch. Reproduced against a real repository: the piped form reported "not breaking" across two genuine `!` commits. That is the same class of silent under-detection this PR exists to fix.
- **The forced major refuses a non-semver `previous_version`.** `set -u` does not help — `PREV` is *set* to empty by `env:`, and `$(( + 1 ))` is valid bash evaluating to `1`, so an empty value would retag a v12.x package as **v1.0.0**. The action's `custom_tag` path performs no `valid()` or monotonicity check, unlike its normal path, so nothing downstream would catch it. The arithmetic was confirmed to match `semver.inc(v, 'major')` for `1.1.0`, `0.3.0`, `0.0.4`, `0.0.0` and `12.261.0`.
- **The gate is a workflow expression and sits *before* the tag step.** `createTag()` runs *inside* `github-tag-action`, and Private Packagist versions packages from git tags rather than GitHub Releases — so any check after the tag step is a post-mortem, not a gate. A bash `[ "$a" -le "$b" ]` would also fail open: it returns 2 on a non-integer operand and, as an `if` condition, does not trip `set -e`.
- **A repo with no tags keeps the normal path.** `previous_tag` is a synthetic `v0.0.0` there, and scanning all history would force `1.0.0` off some ancient commit.

## Test plan

Detection was run against a purpose-built history; all 10 cases pass, including the exact message that shipped as v1.1.1:

```
PASS  nothing since tag                              -> false
PASS  fix only                                       -> false
PASS  feat, no marker                                -> false
PASS  '!' mid-subject must not match                 -> false
PASS  indented footer must not match                 -> false
PASS  the real v1.1.1 subject (bang, no footer)      -> true
PASS  re-tagged, nothing new                         -> false
PASS  hyphenated footer                              -> true
PASS  colon-less footer (parser accepts it)          -> true
PASS  marker not on the newest commit                -> true
```

Forced-major arithmetic, including fail-closed cases:

```
PREV=1.1.0     -> 2.0.0       PREV=""          -> rc=1
PREV=0.3.0     -> 1.0.0       PREV=1.2.0-rc.1  -> rc=1
PREV=0.0.4     -> 1.0.0       PREV=v1.1.0      -> rc=1
PREV=12.261.0  -> 13.0.0      PREV=1.1         -> rc=1
```

**Still outstanding before merge** — this takes effect for all 47 caller repos the moment it lands, since they pin `@main`:

- [ ] End-to-end run on a throwaway repo: `v1.1.0` + `feat(x)!:` → `v2.0.0`; a `chore:` commit → patch; a footer-only breaking commit → major.
- [ ] Confirm the gate blocks *and creates no tag* (check `git/matching-refs/tags`, not just a red run).

## Notes for reviewers

- A breaking commit majors **every** package whose subtree it touched, because splitsh copies the message verbatim into each repo and no per-package breaking signal exists. Over-bumps, never under-bumps. Scope breaking commits narrowly.
- `custom_tag` sets `release_type` to `custom` rather than `major`. Nothing here consumes it, but `build-php-laravel.yaml` and `build-php-v1.yaml` do read this action's outputs — audit them before copying this pattern across.
- The subject check assumes conventional-commit PR titles, since the squash subject comes from the PR title. `git-commit-lint.yaml` documents the convention as `<TICKET-ID>: <description>`, under which a `!` could never appear; repos on that style rely on the footer check instead.
- **The same defect is live in ~13 other repos** that inline their own copy of this action, including the libraries `products-php`, `rp_core`, `RocketShipIt`, `go-config`, `go-errors`, `go-fpsm`, and the app-scaffolding playbooks in `dotfiles`. This PR does not reach any of them.
- The workflow name is inaccurate — nothing here runs `semantic-release` — but renaming it changes the check name on `main` for 47 repos, so that is deliberately left alone.
